### PR TITLE
Refactor plugin initialization to use service context

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -1,18 +1,53 @@
 package eu.nurkert.neverUp2Late;
 
+import eu.nurkert.neverUp2Late.core.PluginContext;
+import eu.nurkert.neverUp2Late.fetcher.GeyserFetcher;
+import eu.nurkert.neverUp2Late.fetcher.PaperFetcher;
+import eu.nurkert.neverUp2Late.fetcher.UpdateFetcher;
 import eu.nurkert.neverUp2Late.handlers.InstallationHandler;
 import eu.nurkert.neverUp2Late.handlers.PersistentPluginHandler;
 import eu.nurkert.neverUp2Late.handlers.UpdateHandler;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Map;
 
 public final class NeverUp2Late extends JavaPlugin {
 
+    private PluginContext context;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
-        PersistentPluginHandler.getInstance();
-        UpdateHandler.getInstance();
-        getServer().getPluginManager().registerEvents(InstallationHandler.getInstance(), this);
+        FileConfiguration configuration = getConfig();
+
+        PersistentPluginHandler persistentPluginHandler = new PersistentPluginHandler(this);
+        InstallationHandler installationHandler = new InstallationHandler(getServer());
+
+        Map<String, UpdateFetcher> fetchers = Map.ofEntries(
+                Map.entry("paper", new PaperFetcher(configuration.getBoolean("ignoreUnstable"))),
+                Map.entry("geyser", new GeyserFetcher())
+        );
+
+        UpdateHandler updateHandler = new UpdateHandler(
+                this,
+                getServer().getScheduler(),
+                configuration,
+                persistentPluginHandler,
+                installationHandler,
+                fetchers
+        );
+
+        context = new PluginContext(
+                this,
+                getServer().getScheduler(),
+                configuration,
+                persistentPluginHandler,
+                updateHandler,
+                installationHandler
+        );
+
+        updateHandler.start();
+        getServer().getPluginManager().registerEvents(installationHandler, this);
     }
 
     @Override
@@ -20,16 +55,7 @@ public final class NeverUp2Late extends JavaPlugin {
         // Plugin shutdown logic
     }
 
-    private static NeverUp2Late plugin;
-
-    public NeverUp2Late() {
-        plugin = this;
-    }
-
-    /**
-     * @return instance of this Spigot-/JavaPlugin
-     */
-    public static NeverUp2Late getInstance() {
-        return plugin;
+    public PluginContext getContext() {
+        return context;
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
@@ -1,0 +1,60 @@
+package eu.nurkert.neverUp2Late.core;
+
+import eu.nurkert.neverUp2Late.handlers.InstallationHandler;
+import eu.nurkert.neverUp2Late.handlers.PersistentPluginHandler;
+import eu.nurkert.neverUp2Late.handlers.UpdateHandler;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitScheduler;
+
+/**
+ * Central registry for plugin level services and shared Bukkit infrastructure components.
+ */
+public class PluginContext {
+
+    private final JavaPlugin plugin;
+    private final BukkitScheduler scheduler;
+    private final FileConfiguration configuration;
+
+    private final PersistentPluginHandler persistentPluginHandler;
+    private final UpdateHandler updateHandler;
+    private final InstallationHandler installationHandler;
+
+    public PluginContext(JavaPlugin plugin,
+                         BukkitScheduler scheduler,
+                         FileConfiguration configuration,
+                         PersistentPluginHandler persistentPluginHandler,
+                         UpdateHandler updateHandler,
+                         InstallationHandler installationHandler) {
+        this.plugin = plugin;
+        this.scheduler = scheduler;
+        this.configuration = configuration;
+        this.persistentPluginHandler = persistentPluginHandler;
+        this.updateHandler = updateHandler;
+        this.installationHandler = installationHandler;
+    }
+
+    public JavaPlugin getPlugin() {
+        return plugin;
+    }
+
+    public BukkitScheduler getScheduler() {
+        return scheduler;
+    }
+
+    public FileConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    public PersistentPluginHandler getPersistentPluginHandler() {
+        return persistentPluginHandler;
+    }
+
+    public UpdateHandler getUpdateHandler() {
+        return updateHandler;
+    }
+
+    public InstallationHandler getInstallationHandler() {
+        return installationHandler;
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcher.java
@@ -1,6 +1,5 @@
 package eu.nurkert.neverUp2Late.fetcher;
 
-import eu.nurkert.neverUp2Late.NeverUp2Late;
 import org.bukkit.Bukkit;
 
 import java.io.BufferedReader;
@@ -26,7 +25,7 @@ public class PaperFetcher implements UpdateFetcher {
     private String latestDownloadUrl;
 
     // Flag to determine whether to fetch only stable versions
-    private boolean fetchStableVersions = NeverUp2Late.getInstance().getConfig().getBoolean("ignoreUnstable");
+    private boolean fetchStableVersions = true;
 
     /**
      * Default constructor that fetches only stable versions.

--- a/src/main/java/eu/nurkert/neverUp2Late/handlers/InstallationHandler.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/handlers/InstallationHandler.java
@@ -1,34 +1,22 @@
 package eu.nurkert.neverUp2Late.handlers;
 
-import org.bukkit.Bukkit;
+import org.bukkit.Server;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 
-import java.util.List;
-
 public class InstallationHandler implements Listener {
 
+        private final Server server;
         private boolean updateAvailable;
 
-        // Step 1: Create a private static instance of the class
-        private static InstallationHandler instance;
-
-        // Step 2: Make the constructor private to prevent instantiation
-        private InstallationHandler() {
-            updateAvailable  = false;
-        }
-
-        // Step 3: Provide a public static method to get the instance of the class
-        public static InstallationHandler getInstance() {
-            if (instance == null) {
-                instance = new InstallationHandler();
-            }
-            return instance;
+        public InstallationHandler(Server server) {
+            this.server = server;
+            this.updateAvailable  = false;
         }
 
         public void updateAvailable() {
-            if(Bukkit.getOnlinePlayers().size() > 0) {
+            if (!server.getOnlinePlayers().isEmpty()) {
                 updateAvailable = true;
             } else {
                 restartServer();
@@ -37,14 +25,12 @@ public class InstallationHandler implements Listener {
 
         @EventHandler
         public void onPlayerLeave(PlayerQuitEvent event) {
-            if(updateAvailable) {
-                if(Bukkit.getOnlinePlayers().size() - 1 == 0) {
-                    restartServer();
-                }
+            if (updateAvailable && server.getOnlinePlayers().size() <= 1) {
+                restartServer();
             }
         }
 
         private void restartServer() {
-            Bukkit.shutdown();
+            server.shutdown();
         }
 }

--- a/src/test/java/eu/nurkert/neverUp2Late/handlers/InstallationHandlerTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/handlers/InstallationHandlerTest.java
@@ -1,0 +1,105 @@
+package eu.nurkert.neverUp2Late.handlers;
+
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InstallationHandlerTest {
+
+    @Test
+    void restartsImmediatelyWhenNoPlayersOnline() {
+        AtomicInteger shutdownCalls = new AtomicInteger();
+        Collection<Player> players = new ArrayList<>();
+
+        Server server = createServer(players, shutdownCalls);
+        InstallationHandler handler = new InstallationHandler(server);
+
+        handler.updateAvailable();
+
+        assertEquals(1, shutdownCalls.get(), "Server should shut down when no players are online");
+    }
+
+    @Test
+    void defersRestartUntilLastPlayerLeaves() {
+        AtomicInteger shutdownCalls = new AtomicInteger();
+        Collection<Player> players = new ArrayList<>();
+        players.add(createPlayer());
+
+        Server server = createServer(players, shutdownCalls);
+        InstallationHandler handler = new InstallationHandler(server);
+
+        handler.updateAvailable();
+        assertEquals(0, shutdownCalls.get(), "Restart must be deferred while players are online");
+
+        handler.onPlayerLeave(new PlayerQuitEvent(createPlayer(), ""));
+        assertEquals(1, shutdownCalls.get(), "Restart should happen once the last player leaves");
+    }
+
+    private Server createServer(Collection<Player> players, AtomicInteger shutdownCalls) {
+        return (Server) Proxy.newProxyInstance(
+                Server.class.getClassLoader(),
+                new Class<?>[]{Server.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getOnlinePlayers":
+                            return players;
+                        case "shutdown":
+                            shutdownCalls.incrementAndGet();
+                            return null;
+                        default:
+                            return defaultValue(method.getReturnType());
+                    }
+                }
+        );
+    }
+
+    private Player createPlayer() {
+        return (Player) Proxy.newProxyInstance(
+                Player.class.getClassLoader(),
+                new Class<?>[]{Player.class},
+                (proxy, method, args) -> defaultValue(method.getReturnType())
+        );
+    }
+
+    private Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (boolean.class.equals(returnType)) {
+            return false;
+        }
+        if (void.class.equals(returnType)) {
+            return null;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0f;
+        }
+        if (returnType == double.class) {
+            return 0d;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        throw new IllegalStateException("Unsupported primitive type: " + returnType);
+    }
+}


### PR DESCRIPTION
## Summary
- add a PluginContext that captures the plugin instance, scheduler, configuration and shared services
- refactor the plugin bootstrap and handlers to use constructor injection instead of static singletons
- cover the installation handler with proxy-based tests to allow isolated verification

## Testing
- not run (no automated test tooling configured)


------
https://chatgpt.com/codex/tasks/task_e_68dcf7103f9c83229fbd47c887c806b6