### PR TITLE
Refactor fetchers to use JSON HTTP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .idea/*
 target/*
 neverup2late.iml
-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>eu.nurkert</groupId>
+    <artifactId>never-up-2-late</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.15.2</jackson.version>
+        <junit.version>5.10.0</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/GeyserFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/GeyserFetcher.java
@@ -1,339 +1,67 @@
 package eu.nurkert.neverUp2Late.fetcher;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import eu.nurkert.neverUp2Late.net.HttpClient;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
- * GeyserFetcher is responsible for fetching the latest Geyser Spigot build
- * compatible with the latest Minecraft version from the Modrinth API.
+ * Fetcher for Geyser builds using the Modrinth API.
  */
-public class GeyserFetcher implements UpdateFetcher {
+public class GeyserFetcher extends JsonUpdateFetcher {
 
-    // Define the API endpoint URL
     private static final String API_URL = "https://api.modrinth.com/v2/project/geyser/version";
+    private static final Set<String> SUPPORTED_LOADERS = Set.of("paper", "spigot");
 
-    // Fields to store the latest build information
-    private String latestVersionNumber;
-    private int latestBuildNumber;
-    private String latestDownloadUrl;
+    public GeyserFetcher() {
+        this(new HttpClient());
+    }
 
-    /**
-     * Loads the latest Geyser build information compatible with the latest Minecraft version.
-     *
-     * @throws Exception If an error occurs during the HTTP request or data processing.
-     */
+    GeyserFetcher(HttpClient httpClient) {
+        super(httpClient);
+    }
+
     @Override
     public void loadLatestBuildInfo() throws Exception {
-        // Fetch the API response
-        String jsonResponse = fetchApiResponse(API_URL);
+        List<VersionResponse> versions = getJson(API_URL, new TypeReference<>() {});
 
-        // Process the API response to extract the latest build information
-        processApiResponse(jsonResponse);
-    }
+        List<VersionResponse> listedVersions = versions.stream()
+                .filter(version -> "listed".equalsIgnoreCase(version.status()))
+                .collect(Collectors.toList());
 
-    /**
-     * Makes an HTTP GET request to the specified API endpoint and returns the JSON response as a string.
-     *
-     * @param apiUrl The URL of the API endpoint.
-     * @return The JSON response from the API as a string.
-     * @throws Exception If an error occurs during the HTTP request.
-     */
-    private String fetchApiResponse(String apiUrl) throws Exception {
-        // Initialize a URL object with the API endpoint
-        URL url = new URL(apiUrl);
-        // Open an HTTP connection to the URL
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setConnectTimeout(5_000);
-        connection.setReadTimeout(10_000);
-        // Set the request method to GET
-        connection.setRequestMethod("GET");
+        String latestMinecraftVersion = findLatestVersion(listedVersions.stream()
+                        .flatMap(version -> version.gameVersions().stream())
+                        .collect(Collectors.toSet()))
+                .orElseThrow(() -> new IOException("No Minecraft versions available"));
 
-        try {
-            // Check the HTTP response code
-            int responseCode = connection.getResponseCode();
-            if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw new RuntimeException("HTTP GET Request Failed with Error code: " + responseCode);
-            }
+        VersionResponse latestBuild = listedVersions.stream()
+                .filter(version -> version.gameVersions().contains(latestMinecraftVersion))
+                .filter(version -> version.loaders().stream().map(loader -> loader.toLowerCase(Locale.ROOT))
+                        .anyMatch(SUPPORTED_LOADERS::contains))
+                .max(Comparator.comparing(VersionResponse::datePublished))
+                .orElseThrow(() -> new IOException("No builds available for version " + latestMinecraftVersion));
 
-            // Read the response from the input stream
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
-                String inputLine;
-                StringBuilder response = new StringBuilder();
-
-                // Append each line of the response
-                while ((inputLine = in.readLine()) != null) {
-                    response.append(inputLine);
-                }
-
-                // Return the response as a string
-                return response.toString();
-            }
-        } finally {
-            connection.disconnect();
-        }
-    }
-
-    /**
-     * Processes the JSON response from the API to find the latest Geyser Spigot build
-     * compatible with the latest Minecraft game version.
-     *
-     * @param jsonResponse The JSON response from the API as a string.
-     */
-    private void processApiResponse(String jsonResponse) {
-        // Remove all whitespace from the JSON response for easier parsing
-        String jsonResponseNoWhitespace = jsonResponse.replaceAll("\\s", "");
-
-        // Remove the outer square brackets to get the array content
-        String jsonArrayString = jsonResponseNoWhitespace.substring(1, jsonResponseNoWhitespace.length() - 1);
-
-        // Split the array content into individual JSON objects
-        List<String> jsonObjects = extractJsonObjects(jsonArrayString);
-
-        // List to store all builds
-        List<Build> builds = new ArrayList<>();
-
-        // Set to store all game versions
-        Set<String> allGameVersions = new HashSet<>();
-
-        // Parse each JSON object string into a Build object
-        for (String jsonObjectString : jsonObjects) {
-            // Extract 'status'
-            String status = extractFieldValue(jsonObjectString, "\"status\":\"([^\"]*)\"");
-            if (!"listed".equals(status)) {
-                continue; // Skip builds that are not listed
-            }
-
-            // Extract 'game_versions'
-            String gameVersionsString = extractFieldValue(jsonObjectString, "\"game_versions\":\\[([^\\]]*)\\]");
-            List<String> gameVersions = extractStringArray(gameVersionsString);
-            allGameVersions.addAll(gameVersions); // Collect all game versions
-
-            // Extract 'loaders'
-            String loadersString = extractFieldValue(jsonObjectString, "\"loaders\":\\[([^\\]]*)\\]");
-            List<String> loaders = extractStringArray(loadersString);
-
-            // Extract other necessary fields
-            String datePublished = extractFieldValue(jsonObjectString, "\"date_published\":\"([^\"]*)\"");
-            String versionNumber = extractFieldValue(jsonObjectString, "\"version_number\":\"([^\"]*)\"");
-            String id = extractFieldValue(jsonObjectString, "\"id\":\"([^\"]*)\"");
-
-            // Extract 'files' array and get the download URL
-            String filesArrayString = extractFieldValue(jsonObjectString, "\"files\":\\[([^\\]]*)\\]");
-            String downloadUrl = null;
-            if (filesArrayString != null) {
-                downloadUrl = extractFieldValue(filesArrayString, "\"url\":\"([^\"]*)\"");
-            }
-
-            // Create a Build object and add it to the list
-            Build build = new Build();
-            build.id = id;
-            build.versionNumber = versionNumber;
-            build.datePublished = datePublished;
-            build.gameVersions = gameVersions;
-            build.loaders = loaders;
-            build.status = status;
-            build.downloadUrl = downloadUrl;
-            builds.add(build);
+        OptionalInt buildNumber = extractBuildNumber(latestBuild.versionNumber());
+        if (buildNumber.isEmpty()) {
+            throw new IOException("Unable to determine build number from version " + latestBuild.versionNumber());
         }
 
-        // Find the latest Minecraft version
-        String latestMinecraftVersion = findLatestMinecraftVersion(allGameVersions);
-        if (latestMinecraftVersion == null) {
-            System.out.println("No game versions found in the builds.");
-            return;
-        }
+        String downloadUrl = latestBuild.files().stream()
+                .sorted(Comparator.comparing(GeyserFile::primary).reversed())
+                .map(GeyserFile::url)
+                .filter(url -> url != null && !url.isBlank())
+                .findFirst()
+                .orElseThrow(() -> new IOException("No download available for version " + latestBuild.versionNumber()));
 
-        // Filter builds that support the latest Minecraft version and have 'paper' or 'spigot' as loaders
-        List<Build> matchingBuilds = new ArrayList<>();
-        for (Build build : builds) {
-            if (!build.gameVersions.contains(latestMinecraftVersion)) {
-                continue;
-            }
-            if (!(build.loaders.contains("paper") || build.loaders.contains("spigot"))) {
-                continue;
-            }
-            matchingBuilds.add(build);
-        }
-
-        // Find the most recent build among the matching builds
-        Build latestBuild = null;
-        for (Build build : matchingBuilds) {
-            if (latestBuild == null) {
-                latestBuild = build;
-            } else {
-                if (build.datePublished.compareTo(latestBuild.datePublished) > 0) {
-                    latestBuild = build;
-                }
-            }
-        }
-
-        // Set the fields with the latest build information
-        if (latestBuild != null) {
-            this.latestVersionNumber = latestBuild.versionNumber;
-            this.latestBuildNumber = extractBuildNumberFromVersion(latestBuild.versionNumber);
-            this.latestDownloadUrl = latestBuild.downloadUrl;
-        } else {
-            System.out.println("No relevant build found for the latest Minecraft version.");
-        }
-    }
-
-    /**
-     * Extracts the build number from the version number string.
-     *
-     * @param versionNumber The version number string, e.g., "2.5.0-b713".
-     * @return The build number as an integer, e.g., 713.
-     */
-    private int extractBuildNumberFromVersion(String versionNumber) {
-        int index = versionNumber.lastIndexOf("-b");
-        if (index != -1 && index + 2 < versionNumber.length()) {
-            String buildNumberStr = versionNumber.substring(index + 2);
-            try {
-                return Integer.parseInt(buildNumberStr);
-            } catch (NumberFormatException e) {
-                System.err.println("Error parsing build number from version: " + versionNumber);
-            }
-        }
-        return -1;
-    }
-
-    /**
-     * Extracts the value of a field from a JSON string using a regular expression.
-     *
-     * @param json         The JSON string.
-     * @param regexPattern The regular expression pattern to match the field.
-     * @return The extracted field value, or null if not found.
-     */
-    private String extractFieldValue(String json, String regexPattern) {
-        Pattern pattern = Pattern.compile(regexPattern);
-        Matcher matcher = pattern.matcher(json);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
-        return null;
-    }
-
-    /**
-     * Extracts an array of strings from a JSON array string.
-     *
-     * @param arrayString The JSON array string.
-     * @return A list of strings representing the array elements.
-     */
-    private List<String> extractStringArray(String arrayString) {
-        List<String> list = new ArrayList<>();
-        if (arrayString == null || arrayString.isEmpty()) {
-            return list;
-        }
-        // Split the array elements
-        String[] elements = arrayString.split(",");
-        for (String element : elements) {
-            // Remove leading and trailing quotes
-            element = element.replaceAll("^\"|\"$", "");
-            list.add(element);
-        }
-        return list;
-    }
-
-    /**
-     * Extracts individual JSON object strings from the JSON array string.
-     *
-     * @param jsonArrayString The JSON array string without the outer brackets.
-     * @return A list of JSON object strings.
-     */
-    private List<String> extractJsonObjects(String jsonArrayString) {
-        List<String> jsonObjects = new ArrayList<>();
-        // Split the JSON array string into individual JSON object strings
-        String[] buildJsonStrings = jsonArrayString.split("\\},\\{");
-        for (int i = 0; i < buildJsonStrings.length; i++) {
-            String buildJsonString = buildJsonStrings[i];
-            if (i == 0) {
-                // First element, add '{' at the beginning and '}' at the end
-                buildJsonString = buildJsonString + "}";
-                buildJsonString = "{" + buildJsonString;
-            } else if (i == buildJsonStrings.length - 1) {
-                // Last element, add '{' at the beginning and '}' at the end
-                buildJsonString = "{" + buildJsonString;
-                buildJsonString = buildJsonString + "}";
-            } else {
-                // Middle elements, add '{' at the beginning and '}' at the end
-                buildJsonString = "{" + buildJsonString + "}";
-            }
-            jsonObjects.add(buildJsonString);
-        }
-        return jsonObjects;
-    }
-
-    /**
-     * Finds the latest Minecraft game version from a set of versions.
-     *
-     * @param gameVersions The set of game versions.
-     * @return The latest game version as a string.
-     */
-    private String findLatestMinecraftVersion(Set<String> gameVersions) {
-        String latestVersion = null;
-        for (String version : gameVersions) {
-            if (latestVersion == null || compareVersionStrings(version, latestVersion) > 0) {
-                latestVersion = version;
-            }
-        }
-        return latestVersion;
-    }
-
-    /**
-     * Compares two version strings.
-     *
-     * @param v1 The first version string.
-     * @param v2 The second version string.
-     * @return A positive number if v1 > v2, negative if v1 < v2, zero if equal.
-     */
-    private int compareVersionStrings(String v1, String v2) {
-        String[] parts1 = v1.split("\\.");
-        String[] parts2 = v2.split("\\.");
-        int len = Math.max(parts1.length, parts2.length);
-        for (int i = 0; i < len; i++) {
-            int num1 = i < parts1.length ? Integer.parseInt(parts1[i]) : 0;
-            int num2 = i < parts2.length ? Integer.parseInt(parts2[i]) : 0;
-            if (num1 != num2) {
-                return num1 - num2;
-            }
-        }
-        return 0;
-    }
-
-    // Getters for the latest build information
-
-    /**
-     * Gets the latest version number.
-     *
-     * @return The latest version number as a string.
-     */
-    @Override
-    public String getLatestVersion() {
-        return latestVersionNumber;
-    }
-
-    /**
-     * Gets the latest build number.
-     *
-     * @return The latest build number as an integer.
-     */
-    @Override
-    public int getLatestBuild() {
-        return latestBuildNumber;
-    }
-
-    /**
-     * Gets the download URL for the latest build.
-     *
-     * @return The latest download URL as a string.
-     */
-    @Override
-    public String getLatestDownloadUrl() {
-        return latestDownloadUrl;
+        setLatestBuildInfo(latestBuild.versionNumber(), buildNumber.getAsInt(), downloadUrl);
     }
 
     @Override
@@ -341,17 +69,25 @@ public class GeyserFetcher implements UpdateFetcher {
         return null;
     }
 
+    private record VersionResponse(
+            @JsonProperty("id") String id,
+            @JsonProperty("version_number") String versionNumber,
+            @JsonProperty("status") String status,
+            @JsonProperty("date_published") Instant datePublished,
+            @JsonProperty("game_versions") List<String> gameVersions,
+            @JsonProperty("loaders") List<String> loaders,
+            @JsonProperty("files") List<GeyserFile> files
+    ) {
+        private VersionResponse {
+            gameVersions = gameVersions == null ? List.of() : List.copyOf(gameVersions);
+            loaders = loaders == null ? List.of() : List.copyOf(loaders);
+            files = files == null ? List.of() : List.copyOf(files);
+        }
+    }
 
-    /**
-     * Inner class representing a build with relevant information.
-     */
-    private static class Build {
-        String id;
-        String versionNumber;
-        String datePublished;
-        List<String> gameVersions;
-        List<String> loaders;
-        String status;
-        String downloadUrl;
+    private record GeyserFile(
+            @JsonProperty("url") String url,
+            @JsonProperty("primary") boolean primary
+    ) {
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/JsonUpdateFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/JsonUpdateFetcher.java
@@ -1,0 +1,151 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import eu.nurkert.neverUp2Late.net.HttpClient;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Base class for update fetchers that communicate with JSON based HTTP APIs.
+ */
+public abstract class JsonUpdateFetcher implements UpdateFetcher {
+
+    private static final Pattern NUMERIC_PATTERN = Pattern.compile("\\d+");
+    private static final Pattern BUILD_NUMBER_PATTERN = Pattern.compile("-b(\\d+)$", Pattern.CASE_INSENSITIVE);
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    private String latestVersion;
+    private int latestBuild;
+    private String latestDownloadUrl;
+
+    protected JsonUpdateFetcher() {
+        this(new HttpClient(), defaultMapper());
+    }
+
+    protected JsonUpdateFetcher(HttpClient httpClient) {
+        this(httpClient, defaultMapper());
+    }
+
+    protected JsonUpdateFetcher(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    private static ObjectMapper defaultMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        return mapper;
+    }
+
+    protected <T> T getJson(String url, Class<T> type) throws IOException {
+        String body = httpClient.get(url);
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Failed to parse response from " + url, e);
+        }
+    }
+
+    protected <T> T getJson(String url, TypeReference<T> type) throws IOException {
+        String body = httpClient.get(url);
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (JsonProcessingException e) {
+            throw new IOException("Failed to parse response from " + url, e);
+        }
+    }
+
+    protected List<String> filterStableVersions(Collection<String> versions) {
+        return versions.stream()
+                .filter(version -> !version.contains("-"))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    protected Optional<String> findLatestVersion(Collection<String> versions) {
+        Comparator<String> comparator = semanticVersionComparator();
+        return versions.stream().max(comparator);
+    }
+
+    protected String requireLatestVersion(Collection<String> versions) throws IOException {
+        return findLatestVersion(versions)
+                .orElseThrow(() -> new IOException("No versions available"));
+    }
+
+    protected Comparator<String> semanticVersionComparator() {
+        return (left, right) -> {
+            List<Integer> leftNumbers = extractNumbers(left);
+            List<Integer> rightNumbers = extractNumbers(right);
+            int max = Math.max(leftNumbers.size(), rightNumbers.size());
+            for (int i = 0; i < max; i++) {
+                int leftValue = i < leftNumbers.size() ? leftNumbers.get(i) : 0;
+                int rightValue = i < rightNumbers.size() ? rightNumbers.get(i) : 0;
+                if (leftValue != rightValue) {
+                    return Integer.compare(leftValue, rightValue);
+                }
+            }
+            return Integer.compare(leftNumbers.size(), rightNumbers.size());
+        };
+    }
+
+    private List<Integer> extractNumbers(String value) {
+        Matcher matcher = NUMERIC_PATTERN.matcher(value);
+        List<Integer> numbers = new ArrayList<>();
+        while (matcher.find()) {
+            numbers.add(Integer.parseInt(matcher.group()));
+        }
+        return numbers;
+    }
+
+    protected int selectLatestBuild(Collection<Integer> builds) throws IOException {
+        return builds.stream()
+                .max(Integer::compareTo)
+                .orElseThrow(() -> new IOException("No builds available"));
+    }
+
+    protected OptionalInt extractBuildNumber(String versionNumber) {
+        Matcher matcher = BUILD_NUMBER_PATTERN.matcher(versionNumber);
+        if (matcher.find()) {
+            return OptionalInt.of(Integer.parseInt(matcher.group(1)));
+        }
+        return OptionalInt.empty();
+    }
+
+    protected void setLatestBuildInfo(String version, int build, String downloadUrl) {
+        this.latestVersion = version;
+        this.latestBuild = build;
+        this.latestDownloadUrl = downloadUrl;
+    }
+
+    @Override
+    public String getLatestVersion() {
+        return latestVersion;
+    }
+
+    @Override
+    public int getLatestBuild() {
+        return latestBuild;
+    }
+
+    @Override
+    public String getLatestDownloadUrl() {
+        return latestDownloadUrl;
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcher.java
@@ -1,332 +1,70 @@
 package eu.nurkert.neverUp2Late.fetcher;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import eu.nurkert.neverUp2Late.net.HttpClient;
 import org.bukkit.Bukkit;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * PaperFetcher is responsible for fetching the latest Paper build
- * compatible with the latest Minecraft version from the PaperMC API or website.
+ * Fetcher for Paper builds using the PaperMC public API.
  */
-public class PaperFetcher implements UpdateFetcher {
+public class PaperFetcher extends JsonUpdateFetcher {
 
-    // Define the API endpoint URL
     private static final String API_URL = "https://api.papermc.io/v2/projects/paper";
 
-    // Fields to store the latest build information
-    private String latestVersion;
-    private int latestBuild;
-    private String latestDownloadUrl;
+    private final boolean fetchStableVersions;
 
-    // Flag to determine whether to fetch only stable versions
-    private boolean fetchStableVersions = true;
-
-    /**
-     * Default constructor that fetches only stable versions.
-     */
     public PaperFetcher() {
+        this(true);
     }
 
-    /**
-     * Constructor that allows specifying whether to fetch only stable versions.
-     *
-     * @param fetchStableVersions Set to true to fetch only stable versions, false to include unstable versions.
-     */
     public PaperFetcher(boolean fetchStableVersions) {
+        this(fetchStableVersions, new HttpClient());
+    }
+
+    PaperFetcher(boolean fetchStableVersions, HttpClient httpClient) {
+        super(httpClient);
         this.fetchStableVersions = fetchStableVersions;
     }
 
-    /**
-     * Loads the latest Paper build information.
-     *
-     * @throws Exception If an error occurs during the HTTP request or data processing.
-     */
     @Override
     public void loadLatestBuildInfo() throws Exception {
-        if (fetchStableVersions) {
-            // Use initial implementation to fetch the latest stable version from the website
-            this.latestVersion = getLatestStableVersionFromWebsite();
-        } else {
-            // Fetch the API response for the project
-            String jsonResponse = fetchApiResponse(API_URL);
-
-            // Process the API response to extract the latest version
-            processApiResponse(jsonResponse);
-        }
-
-        // Fetch builds for the latest version
-        String buildsApiUrl = API_URL + "/versions/" + latestVersion;
-        String buildsResponse = fetchApiResponse(buildsApiUrl);
-
-        // Extract the 'builds' array from the builds response
-        String buildsArrayString = extractFieldValue(buildsResponse, "\"builds\":\\[([^\\]]*)\\]");
-        List<String> builds = extractStringArray(buildsArrayString);
-        if (builds.isEmpty()) {
-            throw new Exception("No builds found for version " + latestVersion);
-        }
-
-        // Get the latest build number (the last in the list)
-        String latestBuildStr = builds.get(builds.size() - 1);
-        this.latestBuild = Integer.parseInt(latestBuildStr);
-
-        // Construct the download URL for the latest build
-        this.latestDownloadUrl = API_URL + "/versions/" + latestVersion + "/builds/" + latestBuild + "/downloads/paper-" + latestVersion + "-" + latestBuild + ".jar";
-    }
-
-    /**
-     * Fetches the latest stable version from the PaperMC website.
-     *
-     * @return The latest stable version as a string.
-     * @throws Exception If an error occurs during the HTTP request or parsing.
-     */
-    private String getLatestStableVersionFromWebsite() throws Exception {
-        String htmlContent = loadHtmlContent("https://papermc.io/downloads/paper");
-
-        // Search for the <h2> element that contains "Get Paper"
-        String h2TagStart = "<h2";
-        int h2StartIndex = htmlContent.indexOf(h2TagStart);
-        while (h2StartIndex != -1) {
-            int h2EndIndex = htmlContent.indexOf("</h2>", h2StartIndex);
-            if (h2EndIndex != -1) {
-                String h2Content = htmlContent.substring(h2StartIndex, h2EndIndex + 5);
-                if (h2Content.contains("Get") && h2Content.contains("Paper")) {
-                    // Search for the <span class="text-blue-600"> within this <h2> element
-                    String spanStartTag = "<span class=\"text-blue-600\">";
-                    int spanStartIndex = h2Content.indexOf(spanStartTag);
-                    if (spanStartIndex != -1) {
-                        int versionStartIndex = spanStartIndex + spanStartTag.length();
-                        int spanEndIndex = h2Content.indexOf("</span>", versionStartIndex);
-                        if (spanEndIndex != -1) {
-                            String version = h2Content.substring(versionStartIndex, spanEndIndex);
-                            return version.trim();
-                        }
-                    }
-                }
-                // Search for the next <h2> element
-                h2StartIndex = htmlContent.indexOf(h2TagStart, h2EndIndex);
-            } else {
-                break;
-            }
-        }
-        // Return null if not found
-        throw new Exception("Could not find the latest stable version on the website.");
-    }
-
-    /**
-     * Loads the HTML content from a given URL.
-     *
-     * @param urlString The URL to load content from.
-     * @return The HTML content as a string.
-     * @throws Exception If an error occurs during the HTTP request.
-     */
-    private String loadHtmlContent(String urlString) throws Exception {
-        StringBuilder result = new StringBuilder();
-        URL url = new URL(urlString);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setConnectTimeout(5_000);
-        conn.setReadTimeout(10_000);
-        conn.setRequestMethod("GET");
-        // Set the User-Agent header
-        conn.setRequestProperty("User-Agent", "PaperFetcher");
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                result.append(line);
-            }
-        } finally {
-            conn.disconnect();
-        }
-        return result.toString();
-    }
-
-    /**
-     * Processes the JSON response from the API to find the latest version.
-     * If fetchStableVersions is true, filters out unstable versions.
-     *
-     * @param jsonResponse The JSON response from the API as a string.
-     * @throws Exception If an error occurs during data processing.
-     */
-    private void processApiResponse(String jsonResponse) throws Exception {
-        // Extract the 'versions' array from the JSON response
-        String versionsArrayString = extractFieldValue(jsonResponse, "\"versions\":\\[([^\\]]*)\\]");
-        List<String> versions = extractStringArray(versionsArrayString);
-        if (versions.isEmpty()) {
-            throw new Exception("No versions found in API response.");
-        }
-
-        // If fetchStableVersions is true, filter out unstable versions
+        ProjectResponse project = getJson(API_URL, ProjectResponse.class);
+        List<String> versions = new ArrayList<>(project.versions());
         if (fetchStableVersions) {
             versions = filterStableVersions(versions);
-            if (versions.isEmpty()) {
-                throw new Exception("No stable versions found in API response.");
-            }
         }
+        String latestVersion = requireLatestVersion(versions);
 
-        // Get the latest version (the last in the list)
-        this.latestVersion = versions.get(versions.size() - 1);
+        VersionResponse versionResponse = getJson(API_URL + "/versions/" + latestVersion, VersionResponse.class);
+        int latestBuild = selectLatestBuild(versionResponse.builds());
+        String downloadUrl = API_URL + "/versions/" + latestVersion + "/builds/" + latestBuild
+                + "/downloads/paper-" + latestVersion + "-" + latestBuild + ".jar";
+
+        setLatestBuildInfo(latestVersion, latestBuild, downloadUrl);
     }
 
-    /**
-     * Filters the list of versions to include only stable versions.
-     *
-     * @param versions The list of versions to filter.
-     * @return A list containing only stable versions.
-     */
-    private List<String> filterStableVersions(List<String> versions) {
-        List<String> stableVersions = new ArrayList<>();
-        for (String version : versions) {
-            if (isStableVersion(version)) {
-                stableVersions.add(version);
-            }
-        }
-        return stableVersions;
-    }
-
-    /**
-     * Determines if a version string represents a stable version.
-     *
-     * @param version The version string to check.
-     * @return True if the version is stable, false otherwise.
-     */
-    private boolean isStableVersion(String version) {
-        // Unstable versions often contain '-' followed by 'pre', 'rc', etc.
-        // Stable versions are in the format of major.minor.patch, e.g., '1.20.1'
-        return !version.contains("-");
-    }
-
-    /**
-     * Makes an HTTP GET request to the specified API endpoint and returns the response as a string.
-     *
-     * @param apiUrl The URL of the API endpoint.
-     * @return The response from the API as a string.
-     * @throws Exception If an error occurs during the HTTP request.
-     */
-    private String fetchApiResponse(String apiUrl) throws Exception {
-        // Initialize a URL object with the API endpoint
-        URL url = new URL(apiUrl);
-        // Open an HTTP connection to the URL
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setConnectTimeout(5_000);
-        connection.setReadTimeout(10_000);
-        // Set the request method to GET
-        connection.setRequestMethod("GET");
-        // Set the User-Agent header
-        connection.setRequestProperty("User-Agent", "PaperFetcher");
-
-        try {
-            // Check the HTTP response code
-            int responseCode = connection.getResponseCode();
-            if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw new RuntimeException("HTTP GET Request Failed with Error code: " + responseCode);
-            }
-
-            // Read the response from the input stream
-            StringBuilder response = new StringBuilder();
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(connection.getInputStream(), "UTF-8"))) {
-                String inputLine;
-
-                // Append each line of the response
-                while ((inputLine = in.readLine()) != null) {
-                    response.append(inputLine);
-                }
-            }
-
-            // Return the response as a string
-            return response.toString();
-        } finally {
-            connection.disconnect();
-        }
-    }
-
-    /**
-     * Extracts the value of a field from a string using a regular expression.
-     *
-     * @param text         The text to search.
-     * @param regexPattern The regular expression pattern to match the field.
-     * @return The extracted field value, or null if not found.
-     */
-    private String extractFieldValue(String text, String regexPattern) {
-        Pattern pattern = Pattern.compile(regexPattern);
-        Matcher matcher = pattern.matcher(text);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
-        return null;
-    }
-
-    /**
-     * Extracts an array of strings from a JSON array string.
-     *
-     * @param arrayString The JSON array string.
-     * @return A list of strings representing the array elements.
-     */
-    private List<String> extractStringArray(String arrayString) {
-        List<String> list = new ArrayList<>();
-        if (arrayString == null || arrayString.isEmpty()) {
-            return list;
-        }
-        // Split the array elements
-        String[] elements = arrayString.split(",");
-        for (String element : elements) {
-            // Remove leading and trailing quotes
-            element = element.replaceAll("^\"|\"$", "");
-            list.add(element.trim());
-        }
-        return list;
-    }
-
-    // Getters for the latest build information
-
-    /**
-     * Gets the latest version.
-     *
-     * @return The latest version as a string.
-     */
-    @Override
-    public String getLatestVersion() {
-        return latestVersion;
-    }
-
-    /**
-     * Gets the latest build number.
-     *
-     * @return The latest build number as an integer.
-     */
-    @Override
-    public int getLatestBuild() {
-        return latestBuild;
-    }
-
-    /**
-     * Gets the download URL for the latest build.
-     *
-     * @return The latest download URL as a string.
-     */
-    @Override
-    public String getLatestDownloadUrl() {
-        return latestDownloadUrl;
-    }
-
-    /**
-     * Gets the installed Minecraft version from the server.
-     *
-     * @return The installed Minecraft version as a string.
-     */
     @Override
     public String getInstalledVersion() {
-        // Gets the full version string, e.g., "git-Paper-283 (MC: 1.16.5)"
         String fullVersion = Bukkit.getVersion();
+        int start = fullVersion.indexOf("MC: ");
+        if (start == -1) {
+            return fullVersion;
+        }
+        return fullVersion.substring(start + 4, fullVersion.length() - 1);
+    }
 
-        // Extracts the Minecraft version from the full version string
-        String minecraftVersion = fullVersion.substring(fullVersion.indexOf("MC: ") + 4, fullVersion.length() - 1);
+    private record ProjectResponse(@JsonProperty("versions") List<String> versions) {
+        private ProjectResponse {
+            versions = versions == null ? List.of() : List.copyOf(versions);
+        }
+    }
 
-        return minecraftVersion;
+    private record VersionResponse(@JsonProperty("builds") List<Integer> builds) {
+        private VersionResponse {
+            builds = builds == null ? List.of() : List.copyOf(builds);
+        }
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
@@ -1,0 +1,69 @@
+package eu.nurkert.neverUp2Late.net;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Lightweight HTTP client wrapper that provides sane defaults for timeouts,
+ * headers and error handling.
+ */
+public class HttpClient {
+
+    private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final Map<String, String> DEFAULT_HEADERS = Map.of("User-Agent", "never-up-2-late/1.0");
+
+    private final java.net.http.HttpClient client;
+    private final Duration requestTimeout;
+    private final Map<String, String> defaultHeaders;
+
+    public HttpClient() {
+        this(java.net.http.HttpClient.newBuilder()
+                        .connectTimeout(DEFAULT_CONNECT_TIMEOUT)
+                        .build(),
+                DEFAULT_REQUEST_TIMEOUT,
+                DEFAULT_HEADERS);
+    }
+
+    protected HttpClient(java.net.http.HttpClient client, Duration requestTimeout, Map<String, String> defaultHeaders) {
+        this.client = Objects.requireNonNull(client, "client");
+        this.requestTimeout = Objects.requireNonNull(requestTimeout, "requestTimeout");
+        this.defaultHeaders = Map.copyOf(defaultHeaders);
+    }
+
+    /**
+     * Executes an HTTP GET request and returns the response body as a string.
+     *
+     * @param url the URL to invoke
+     * @return response body
+     * @throws IOException when the request fails or returns a non-successful status code
+     */
+    public String get(String url) throws IOException {
+        try {
+            return doGet(url);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Request interrupted", e);
+        }
+    }
+
+    protected String doGet(String url) throws IOException, InterruptedException {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(url))
+                .timeout(requestTimeout)
+                .GET();
+        defaultHeaders.forEach(builder::header);
+
+        HttpResponse<String> response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        int statusCode = response.statusCode();
+        if (statusCode >= 200 && statusCode < 300) {
+            return response.body();
+        }
+        throw new HttpException(url, statusCode, response.body());
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/net/HttpException.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/net/HttpException.java
@@ -1,0 +1,32 @@
+package eu.nurkert.neverUp2Late.net;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when an HTTP request returns a non-successful status code.
+ */
+public class HttpException extends IOException {
+
+    private final String url;
+    private final int statusCode;
+    private final String responseBody;
+
+    public HttpException(String url, int statusCode, String responseBody) {
+        super("Request to " + url + " failed with status code " + statusCode);
+        this.url = url;
+        this.statusCode = statusCode;
+        this.responseBody = responseBody;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getResponseBody() {
+        return responseBody;
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/update/UpdateSourceRegistry.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/update/UpdateSourceRegistry.java
@@ -2,8 +2,8 @@ package eu.nurkert.neverUp2Late.update;
 
 import eu.nurkert.neverUp2Late.fetcher.UpdateFetcher;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.MemoryConfiguration;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;

--- a/src/test/java/eu/nurkert/neverUp2Late/fetcher/GeyserFetcherTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/fetcher/GeyserFetcherTest.java
@@ -1,0 +1,107 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import eu.nurkert.neverUp2Late.net.HttpClient;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GeyserFetcherTest {
+
+    @Test
+    void selectsLatestListedBuildForLatestMinecraftVersion() throws Exception {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.modrinth.com/v2/project/geyser/version",
+                """
+                        [
+                          {
+                            "id": "1",
+                            "version_number": "2.1.0-b100",
+                            "status": "listed",
+                            "date_published": "2023-09-10T10:15:30Z",
+                            "game_versions": ["1.20.1", "1.20"],
+                            "loaders": ["spigot"],
+                            "files": [
+                              { "url": "https://example.com/100.jar", "primary": true }
+                            ]
+                          },
+                          {
+                            "id": "2",
+                            "version_number": "2.1.1-b105",
+                            "status": "listed",
+                            "date_published": "2023-09-12T10:15:30Z",
+                            "game_versions": ["1.20.1"],
+                            "loaders": ["paper"],
+                            "files": [
+                              { "url": "https://example.com/105.jar", "primary": true }
+                            ]
+                          },
+                          {
+                            "id": "3",
+                            "version_number": "2.0.0-b90",
+                            "status": "unlisted",
+                            "date_published": "2023-09-11T10:15:30Z",
+                            "game_versions": ["1.19"],
+                            "loaders": ["spigot"],
+                            "files": [
+                              { "url": "https://example.com/90.jar", "primary": true }
+                            ]
+                          }
+                        ]
+                        """);
+
+        GeyserFetcher fetcher = new GeyserFetcher(new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("2.1.1-b105", fetcher.getLatestVersion());
+        assertEquals(105, fetcher.getLatestBuild());
+        assertEquals("https://example.com/105.jar", fetcher.getLatestDownloadUrl());
+    }
+
+    @Test
+    void failsWhenBuildNumberCannotBeExtracted() {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.modrinth.com/v2/project/geyser/version",
+                """
+                        [
+                          {
+                            "id": "1",
+                            "version_number": "2.1.0",
+                            "status": "listed",
+                            "date_published": "2023-09-10T10:15:30Z",
+                            "game_versions": ["1.20.1"],
+                            "loaders": ["paper"],
+                            "files": [
+                              { "url": "https://example.com/100.jar", "primary": true }
+                            ]
+                          }
+                        ]
+                        """);
+
+        GeyserFetcher fetcher = new GeyserFetcher(new StubHttpClient(responses));
+        assertThrows(IOException.class, fetcher::loadLatestBuildInfo);
+    }
+
+    private static class StubHttpClient extends HttpClient {
+        private final Map<String, String> responses;
+
+        StubHttpClient(Map<String, String> responses) {
+            super(java.net.http.HttpClient.newBuilder().build(), Duration.ofSeconds(1), Map.of());
+            this.responses = responses;
+        }
+
+        @Override
+        protected String doGet(String url) throws IOException {
+            String response = responses.get(url);
+            if (response == null) {
+                throw new IOException("No stubbed response for " + url);
+            }
+            return response;
+        }
+    }
+}

--- a/src/test/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcherTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcherTest.java
@@ -1,0 +1,96 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import eu.nurkert.neverUp2Late.net.HttpClient;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PaperFetcherTest {
+
+    @Test
+    void loadsLatestStableBuildFromApiResponses() throws Exception {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.papermc.io/v2/projects/paper",
+                """
+                        {
+                          "versions": ["1.19.4", "1.20", "1.20.1", "1.20.2-rc1"]
+                        }
+                        """);
+        responses.put("https://api.papermc.io/v2/projects/paper/versions/1.20.1",
+                """
+                        {
+                          "builds": [14, 15, 16]
+                        }
+                        """);
+
+        PaperFetcher fetcher = new PaperFetcher(true, new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("1.20.1", fetcher.getLatestVersion());
+        assertEquals(16, fetcher.getLatestBuild());
+        assertEquals("https://api.papermc.io/v2/projects/paper/versions/1.20.1/builds/16/downloads/paper-1.20.1-16.jar",
+                fetcher.getLatestDownloadUrl());
+    }
+
+    @Test
+    void includesUnstableVersionsWhenRequested() throws Exception {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.papermc.io/v2/projects/paper",
+                """
+                        {
+                          "versions": ["1.20.1", "1.20.2-rc1"]
+                        }
+                        """);
+        responses.put("https://api.papermc.io/v2/projects/paper/versions/1.20.2-rc1",
+                """
+                        {
+                          "builds": [1, 2]
+                        }
+                        """);
+
+        PaperFetcher fetcher = new PaperFetcher(false, new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("1.20.2-rc1", fetcher.getLatestVersion());
+        assertEquals(2, fetcher.getLatestBuild());
+    }
+
+    @Test
+    void throwsWhenBuildInformationMissing() {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.papermc.io/v2/projects/paper",
+                """
+                        {
+                          "versions": ["1.20.1"]
+                        }
+                        """);
+        // Missing build information
+
+        PaperFetcher fetcher = new PaperFetcher(true, new StubHttpClient(responses));
+        assertThrows(IOException.class, fetcher::loadLatestBuildInfo);
+    }
+
+    private static class StubHttpClient extends HttpClient {
+        private final Map<String, String> responses;
+
+        StubHttpClient(Map<String, String> responses) {
+            super(java.net.http.HttpClient.newBuilder().build(), Duration.ofSeconds(1), Map.of());
+            this.responses = responses;
+        }
+
+        @Override
+        protected String doGet(String url) throws IOException {
+            String response = responses.get(url);
+            if (response == null) {
+                throw new IOException("No stubbed response for " + url);
+            }
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Maven build with Jackson, Java 17 compiler settings, and test dependencies
- introduce a reusable HTTP client plus JSON-based fetcher superclass for update sources
- refactor Paper and Geyser fetchers to use DTO parsing and add regression tests for their JSON handling

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dcfb3427ac8322bea150838b5dbf2b