### PR TITLE
Add structured update state persistence

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/handlers/PersistentPluginHandler.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/handlers/PersistentPluginHandler.java
@@ -1,91 +1,40 @@
 package eu.nurkert.neverUp2Late.handlers;
 
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
+import eu.nurkert.neverUp2Late.persistence.UpdateStateRepository;
+import eu.nurkert.neverUp2Late.persistence.UpdateStateRepository.PluginState;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.Optional;
 
 public class PersistentPluginHandler {
 
-    private final PluginsFile pluginsFile;
-    private final FileConfiguration config;
+    private final UpdateStateRepository repository;
 
     public PersistentPluginHandler(JavaPlugin plugin) {
-        pluginsFile = new PluginsFile(plugin);
-        config = pluginsFile.getConfig();
+        this(UpdateStateRepository.forPlugin(plugin));
     }
 
-    public void set(String path, Object value) {
-        config.set(path, value);
-        pluginsFile.save();
-    }
-    public int getBuild(String path) {
-        return config.get(path) != null ? config.getInt(path) : -1;
+    public PersistentPluginHandler(UpdateStateRepository repository) {
+        this.repository = repository;
     }
 
-    /**
-     * Checks if the given plugin entry exists.
-     *
-     * @param pluginName The name of the plugin.
-     * @return true if an entry exists, false otherwise.
-     */
+    public void saveLatestBuild(String pluginName, int build, String version) {
+        repository.saveLatestBuild(pluginName, build, version);
+    }
+
+    public int getStoredBuild(String pluginName) {
+        return repository.getStoredBuild(pluginName);
+    }
+
+    public String getStoredVersion(String pluginName) {
+        return repository.getStoredVersion(pluginName);
+    }
+
+    public Optional<PluginState> getPluginState(String pluginName) {
+        return repository.find(pluginName);
+    }
+
     public boolean hasPluginInfo(String pluginName) {
-        return config.contains("plugins." + pluginName);
-    }
-
-    /**
-     * Inner class to manage the plugins.yml file.
-     */
-    public static class PluginsFile {
-
-        private final String filename = "plugins.yml";
-        private final JavaPlugin plugin;
-        private final Logger logger;
-        private File dataFolder;
-        private File pluginsYML;
-        private FileConfiguration plugins;
-
-        public PluginsFile(JavaPlugin plugin) {
-            this.plugin = plugin;
-            this.logger = plugin.getLogger();
-            init();
-        }
-
-        private void init() {
-            dataFolder = plugin.getDataFolder();
-
-            if (!dataFolder.exists() && !dataFolder.mkdirs()) {
-                logger.log(Level.WARNING, "Could not create plugin data folder at {0}", dataFolder.getAbsolutePath());
-            }
-
-            pluginsYML = new File(dataFolder, filename);
-            if (!pluginsYML.exists()) {
-                try {
-                    if (!pluginsYML.createNewFile()) {
-                        logger.log(Level.WARNING, "Unable to create {0}", pluginsYML.getAbsolutePath());
-                    }
-                } catch (IOException e) {
-                    logger.log(Level.SEVERE, "Failed to create " + filename, e);
-                }
-            }
-
-            plugins = YamlConfiguration.loadConfiguration(pluginsYML);
-        }
-
-        public FileConfiguration getConfig() {
-            return plugins;
-        }
-
-        public void save() {
-            try {
-                plugins.save(pluginsYML);
-            } catch (IOException e) {
-                logger.log(Level.SEVERE, "Failed to save " + filename, e);
-            }
-        }
+        return repository.hasPluginInfo(pluginName);
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/persistence/UpdateStateRepository.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/persistence/UpdateStateRepository.java
@@ -1,0 +1,272 @@
+package eu.nurkert.neverUp2Late.persistence;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Repository that manages the persistent update state stored in {@code plugins.yml}.
+ *
+ * <p>The repository normalizes the configuration into the schema</p>
+ *
+ * <pre>
+ * plugins:
+ *   &lt;sourceId&gt;:
+ *     build: &lt;int&gt;
+ *     version: &lt;string&gt;
+ * </pre>
+ *
+ * <p>Legacy structures are migrated automatically and written back to disk.</p>
+ */
+public class UpdateStateRepository {
+
+    private static final String ROOT_NODE = "plugins";
+    private static final String BUILD_NODE = "build";
+    private static final String VERSION_NODE = "version";
+    private static final String FILE_NAME = "plugins.yml";
+
+    private final File dataFolder;
+    private final Logger logger;
+    private final File stateFile;
+    private FileConfiguration configuration;
+
+    public UpdateStateRepository(File dataFolder, Logger logger) {
+        this.dataFolder = dataFolder;
+        this.logger = logger;
+        this.stateFile = new File(dataFolder, FILE_NAME);
+        initialise();
+    }
+
+    public static UpdateStateRepository forPlugin(JavaPlugin plugin) {
+        return new UpdateStateRepository(plugin.getDataFolder(), plugin.getLogger());
+    }
+
+    private void initialise() {
+        ensureDataFolderExists();
+        ensureStateFileExists();
+
+        configuration = YamlConfiguration.loadConfiguration(stateFile);
+
+        boolean mutated = migrateLegacyState();
+        mutated |= ensurePluginsSectionExists();
+        validateSchema();
+
+        if (mutated) {
+            saveInternal();
+        }
+    }
+
+    private void ensureDataFolderExists() {
+        if (!dataFolder.exists() && !dataFolder.mkdirs()) {
+            logger.log(Level.WARNING, "Could not create plugin data folder at {0}", dataFolder.getAbsolutePath());
+        }
+    }
+
+    private void ensureStateFileExists() {
+        if (!stateFile.exists()) {
+            try {
+                if (!stateFile.createNewFile()) {
+                    logger.log(Level.WARNING, "Unable to create {0}", stateFile.getAbsolutePath());
+                }
+            } catch (IOException e) {
+                logger.log(Level.SEVERE, "Failed to create " + FILE_NAME, e);
+            }
+        }
+    }
+
+    private boolean ensurePluginsSectionExists() {
+        if (configuration.getConfigurationSection(ROOT_NODE) == null) {
+            configuration.createSection(ROOT_NODE);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean migrateLegacyState() {
+        boolean mutated = false;
+
+        List<String> topLevelKeys = new ArrayList<>(configuration.getKeys(false));
+        for (String key : topLevelKeys) {
+            if (ROOT_NODE.equals(key)) {
+                continue;
+            }
+            Object value = configuration.get(key);
+            if (value instanceof Number number) {
+                configuration.set(pathForBuild(key), number.intValue());
+                mutated = true;
+            } else if (value instanceof String string) {
+                configuration.set(pathForVersion(key), string);
+                mutated = true;
+            } else if (value instanceof ConfigurationSection section) {
+                copySection(section, configuration.createSection(ROOT_NODE + "." + key));
+                mutated = true;
+            } else if (value != null) {
+                logger.log(Level.WARNING, "Removing unsupported legacy entry {0} from update state", key);
+                mutated = true;
+            }
+            configuration.set(key, null);
+        }
+
+        ConfigurationSection pluginsSection = configuration.getConfigurationSection(ROOT_NODE);
+        if (pluginsSection == null) {
+            return mutated;
+        }
+
+        List<String> pluginKeys = new ArrayList<>(pluginsSection.getKeys(false));
+        for (String pluginKey : pluginKeys) {
+            Object value = pluginsSection.get(pluginKey);
+            if (value instanceof ConfigurationSection section) {
+                mutated |= normalisePluginSection(section, pluginKey);
+                continue;
+            }
+            if (value instanceof Number number) {
+                pluginsSection.set(pluginKey, null);
+                pluginsSection.set(pluginKey + "." + BUILD_NODE, number.intValue());
+                mutated = true;
+                continue;
+            }
+            if (value instanceof String string) {
+                pluginsSection.set(pluginKey, null);
+                pluginsSection.set(pluginKey + "." + VERSION_NODE, string);
+                mutated = true;
+                continue;
+            }
+            if (value == null) {
+                pluginsSection.set(pluginKey, null);
+                mutated = true;
+                continue;
+            }
+            logger.log(Level.WARNING, "Removing unsupported value for plugin entry {0}", pluginKey);
+            pluginsSection.set(pluginKey, null);
+            mutated = true;
+        }
+
+        return mutated;
+    }
+
+    private boolean normalisePluginSection(ConfigurationSection section, String pluginKey) {
+        boolean mutated = false;
+        List<String> keys = new ArrayList<>(section.getKeys(false));
+        for (String childKey : keys) {
+            if (BUILD_NODE.equals(childKey)) {
+                Object value = section.get(childKey);
+                if (!(value instanceof Number)) {
+                    int build = section.getInt(childKey);
+                    section.set(childKey, build);
+                    mutated = true;
+                }
+            } else if (VERSION_NODE.equals(childKey)) {
+                Object value = section.get(childKey);
+                if (value != null && !(value instanceof String)) {
+                    section.set(childKey, value.toString());
+                    mutated = true;
+                }
+            } else {
+                logger.log(Level.WARNING,
+                        "Removing unknown field {0} for plugin entry {1}", new Object[]{childKey, pluginKey});
+                section.set(childKey, null);
+                mutated = true;
+            }
+        }
+        return mutated;
+    }
+
+    private void validateSchema() {
+        ConfigurationSection pluginsSection = configuration.getConfigurationSection(ROOT_NODE);
+        if (pluginsSection == null) {
+            throw new IllegalStateException("Missing '" + ROOT_NODE + "' section in update state file");
+        }
+        for (String pluginKey : pluginsSection.getKeys(false)) {
+            ConfigurationSection section = pluginsSection.getConfigurationSection(pluginKey);
+            if (section == null) {
+                throw new IllegalStateException("Plugin entry '" + pluginKey + "' must be a configuration section");
+            }
+            for (String childKey : section.getKeys(false)) {
+                if (!BUILD_NODE.equals(childKey) && !VERSION_NODE.equals(childKey)) {
+                    throw new IllegalStateException(
+                            "Unknown field '" + childKey + "' for plugin entry '" + pluginKey + "'");
+                }
+            }
+        }
+    }
+
+    public Optional<PluginState> find(String pluginName) {
+        ConfigurationSection section = configuration.getConfigurationSection(pathForPlugin(pluginName));
+        if (section == null) {
+            return Optional.empty();
+        }
+        boolean hasBuild = section.contains(BUILD_NODE);
+        boolean hasVersion = section.contains(VERSION_NODE);
+        if (!hasBuild && !hasVersion) {
+            return Optional.empty();
+        }
+        int build = hasBuild ? section.getInt(BUILD_NODE) : -1;
+        String version = hasVersion ? section.getString(VERSION_NODE) : null;
+        return Optional.of(new PluginState(build, version));
+    }
+
+    public boolean hasPluginInfo(String pluginName) {
+        return find(pluginName).isPresent();
+    }
+
+    public int getStoredBuild(String pluginName) {
+        return find(pluginName).map(PluginState::build).orElse(-1);
+    }
+
+    public String getStoredVersion(String pluginName) {
+        return find(pluginName).map(PluginState::version).orElse(null);
+    }
+
+    public void saveLatestBuild(String pluginName, int build, String version) {
+        configuration.set(pathForBuild(pluginName), build);
+        if (version != null) {
+            configuration.set(pathForVersion(pluginName), version);
+        } else {
+            configuration.set(pathForVersion(pluginName), null);
+        }
+        saveInternal();
+    }
+
+    private String pathForPlugin(String pluginName) {
+        return ROOT_NODE + "." + pluginName;
+    }
+
+    private String pathForBuild(String pluginName) {
+        return pathForPlugin(pluginName) + "." + BUILD_NODE;
+    }
+
+    private String pathForVersion(String pluginName) {
+        return pathForPlugin(pluginName) + "." + VERSION_NODE;
+    }
+
+    private void saveInternal() {
+        try {
+            configuration.save(stateFile);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to save update state", e);
+        }
+    }
+
+    private void copySection(ConfigurationSection source, ConfigurationSection target) {
+        for (String key : source.getKeys(false)) {
+            Object value = source.get(key);
+            if (value instanceof ConfigurationSection nestedSource) {
+                copySection(nestedSource, target.createSection(key));
+            } else {
+                target.set(key, value);
+            }
+        }
+    }
+
+    public record PluginState(int build, String version) {
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/update/FetchUpdateStep.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/update/FetchUpdateStep.java
@@ -44,7 +44,7 @@ public class FetchUpdateStep implements UpdateStep {
 
     private boolean isUpdateRequired(UpdateContext context, UpdateFetcher fetcher) {
         String key = context.getSource().getName();
-        int storedBuild = persistentPluginHandler.getBuild(key);
+        int storedBuild = persistentPluginHandler.getStoredBuild(key);
         if (storedBuild < fetcher.getLatestBuild()) {
             return true;
         }

--- a/src/main/java/eu/nurkert/neverUp2Late/update/InstallUpdateStep.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/update/InstallUpdateStep.java
@@ -25,7 +25,10 @@ public class InstallUpdateStep implements UpdateStep {
         }
 
         String key = context.getSource().getName();
-        persistentPluginHandler.set(key, context.getLatestBuild());
+        persistentPluginHandler.saveLatestBuild(
+                key,
+                context.getLatestBuild(),
+                context.getLatestVersion());
 
         UpdateCompletedEvent event = new UpdateCompletedEvent(
                 context.getSource(),

--- a/src/test/java/eu/nurkert/neverUp2Late/persistence/UpdateStateRepositoryTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/persistence/UpdateStateRepositoryTest.java
@@ -1,0 +1,67 @@
+package eu.nurkert.neverUp2Late.persistence;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UpdateStateRepositoryTest {
+
+    private final Logger logger = Logger.getLogger("test");
+
+    @Test
+    void savesAndLoadsLatestBuild(@TempDir Path tempDir) {
+        UpdateStateRepository repository = new UpdateStateRepository(tempDir.toFile(), logger);
+
+        repository.saveLatestBuild("paper", 123, "1.20.1");
+
+        File stateFile = tempDir.resolve("plugins.yml").toFile();
+        YamlConfiguration configuration = YamlConfiguration.loadConfiguration(stateFile);
+
+        assertEquals(123, configuration.getInt("plugins.paper.build"));
+        assertEquals("1.20.1", configuration.getString("plugins.paper.version"));
+
+        Optional<UpdateStateRepository.PluginState> state = repository.find("paper");
+        assertTrue(state.isPresent());
+        assertEquals(123, state.get().build());
+        assertEquals("1.20.1", state.get().version());
+    }
+
+    @Test
+    void clearsVersionWhenNotProvided(@TempDir Path tempDir) {
+        UpdateStateRepository repository = new UpdateStateRepository(tempDir.toFile(), logger);
+        repository.saveLatestBuild("paper", 100, "1.0.0");
+
+        repository.saveLatestBuild("paper", 101, null);
+
+        File stateFile = tempDir.resolve("plugins.yml").toFile();
+        YamlConfiguration configuration = YamlConfiguration.loadConfiguration(stateFile);
+        assertEquals(101, configuration.getInt("plugins.paper.build"));
+        assertFalse(configuration.contains("plugins.paper.version"));
+    }
+
+    @Test
+    void migratesLegacyStructure(@TempDir Path tempDir) throws IOException {
+        Path stateFile = tempDir.resolve("plugins.yml");
+        Files.writeString(stateFile, "paper: 10\nplugins:\n  geyser: 5\n");
+
+        UpdateStateRepository repository = new UpdateStateRepository(tempDir.toFile(), logger);
+
+        assertEquals(10, repository.getStoredBuild("paper"));
+        assertEquals(5, repository.getStoredBuild("geyser"));
+
+        YamlConfiguration configuration = YamlConfiguration.loadConfiguration(stateFile.toFile());
+        assertEquals(10, configuration.getInt("plugins.paper.build"));
+        assertEquals(5, configuration.getInt("plugins.geyser.build"));
+        assertFalse(configuration.contains("paper"), "Legacy root node should be removed");
+        assertEquals(-1, repository.getStoredBuild("unknown"));
+    }
+}


### PR DESCRIPTION
## Summary
- add an UpdateStateRepository that enforces the plugins.<name>.build/version schema and migrates legacy data
- refactor PersistentPluginHandler and update steps to use the structured repository methods
- add tests covering persistence read/write paths and legacy file migration

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68dcfc41d3ec832295a54d6d2d959fb4