### PR TITLE
Add GitHub release update fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,22 @@ updates:
 ```
 
 Additional sources can be registered by adding new entries to `updates.sources`. Point `type` to either the short alias (which resolves to a fetcher within this plugin) or the fully qualified class name of a custom `UpdateFetcher` implementation.
+
+### GitHub release sources
+
+To track releases that are published on GitHub, set the source `type` to `githubRelease` and provide the repository details inside the `options` block:
+
+```yaml
+    - name: examplePlugin
+      type: githubRelease
+      target: plugins
+      filename: "ExamplePlugin.jar"
+      options:
+        owner: example
+        repository: example-plugin
+        assetPattern: ".*paper.*\\.jar$"   # optional regex filter applied to browser_download_url
+        allowPrerelease: false               # optional, include pre-releases when true
+        installedPlugin: "ExamplePlugin"    # optional, used to detect the currently installed version
+```
+
+If `assetPattern` is omitted the first asset with a download URL is used. When `installedPlugin` is configured the fetcher queries Bukkit's `PluginManager` to determine the installed version, otherwise it returns `null`.

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
@@ -1,0 +1,147 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import eu.nurkert.neverUp2Late.net.HttpClient;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Fetcher that retrieves release information from the GitHub Releases API.
+ */
+public class GithubReleaseFetcher extends JsonUpdateFetcher {
+
+    private static final String API_TEMPLATE = "https://api.github.com/repos/%s/%s/releases";
+
+    private final String owner;
+    private final String repository;
+    private final Pattern assetPattern;
+    private final boolean allowPrerelease;
+    private final String installedPluginName;
+
+    public GithubReleaseFetcher(ConfigurationSection options) {
+        this(options, new HttpClient());
+    }
+
+    GithubReleaseFetcher(ConfigurationSection options, HttpClient httpClient) {
+        super(httpClient);
+        Objects.requireNonNull(options, "options");
+
+        this.owner = requireOption(options, "owner");
+        this.repository = requireOption(options, "repository");
+        String patternValue = trimToNull(options.getString("assetPattern"));
+        this.assetPattern = patternValue != null ? Pattern.compile(patternValue) : null;
+        this.allowPrerelease = options.getBoolean("allowPrerelease", false);
+        this.installedPluginName = trimToNull(options.getString("installedPlugin"));
+    }
+
+    @Override
+    public void loadLatestBuildInfo() throws Exception {
+        List<Release> releases = getJson(buildUrl(), new TypeReference<>() {});
+        if (releases == null || releases.isEmpty()) {
+            throw new IOException("No releases returned for " + owner + "/" + repository);
+        }
+
+        Release latest = releases.stream()
+                .filter(release -> !release.draft())
+                .filter(release -> allowPrerelease || !release.prerelease())
+                .max(Comparator
+                        .comparing(GithubReleaseFetcher::publishedAtOrMin)
+                        .thenComparingLong(Release::id))
+                .orElseThrow(() -> new IOException("No suitable releases found for " + owner + "/" + repository));
+
+        String tagName = trimToNull(latest.tagName());
+        if (tagName == null) {
+            throw new IOException("Latest release for " + owner + "/" + repository + " is missing a tag name");
+        }
+
+        String downloadUrl = latest.assets().stream()
+                .map(Asset::browserDownloadUrl)
+                .map(GithubReleaseFetcher::trimToNull)
+                .filter(Objects::nonNull)
+                .filter(url -> assetPattern == null || assetPattern.matcher(url).find())
+                .findFirst()
+                .orElseThrow(() -> new IOException("No asset download URL" +
+                        (assetPattern != null ? " matching pattern " + assetPattern.pattern() : "") +
+                        " for release " + tagName));
+
+        int build = Math.toIntExact(latest.id());
+        setLatestBuildInfo(tagName, build, downloadUrl);
+    }
+
+    @Override
+    public String getInstalledVersion() {
+        if (installedPluginName == null) {
+            return null;
+        }
+
+        PluginManager pluginManager = Bukkit.getPluginManager();
+        if (pluginManager == null) {
+            return null;
+        }
+
+        Plugin plugin = pluginManager.getPlugin(installedPluginName);
+        if (plugin == null) {
+            return null;
+        }
+
+        return plugin.getDescription().getVersion();
+    }
+
+    private static Instant publishedAtOrMin(Release release) {
+        Instant publishedAt = release.publishedAt();
+        if (publishedAt != null) {
+            return publishedAt;
+        }
+        Instant createdAt = release.createdAt();
+        return createdAt != null ? createdAt : Instant.MIN;
+    }
+
+    private static String requireOption(ConfigurationSection section, String key) {
+        String value = trimToNull(section.getString(key));
+        if (value == null) {
+            throw new IllegalArgumentException("Missing required option '" + key + "'");
+        }
+        return value;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String buildUrl() {
+        return String.format(API_TEMPLATE, owner, repository);
+    }
+
+    private record Release(
+            @JsonProperty("id") long id,
+            @JsonProperty("tag_name") String tagName,
+            @JsonProperty("draft") boolean draft,
+            @JsonProperty("prerelease") boolean prerelease,
+            @JsonProperty("published_at") Instant publishedAt,
+            @JsonProperty("created_at") Instant createdAt,
+            @JsonProperty("assets") List<Asset> assets
+    ) {
+        private Release {
+            assets = assets == null ? List.of() : List.copyOf(assets);
+        }
+    }
+
+    private record Asset(
+            @JsonProperty("browser_download_url") String browserDownloadUrl
+    ) {
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,3 +28,14 @@ updates:
       type: geyser
       target: plugins
       filename: "Geyser-Spigot.jar"
+
+    - name: examplePlugin
+      type: githubRelease
+      target: plugins
+      filename: "ExamplePlugin.jar"
+      options:
+        owner: example
+        repository: example-plugin
+        # assetPattern: ".*paper.*\\.jar$"   # optional regex to select a specific asset
+        # allowPrerelease: false              # optional, defaults to false
+        # installedPlugin: "ExamplePlugin"   # optional, used to read the installed version

--- a/src/test/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcherTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcherTest.java
@@ -1,0 +1,167 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import eu.nurkert.neverUp2Late.net.HttpClient;
+import org.bukkit.configuration.MemoryConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GithubReleaseFetcherTest {
+
+    @Test
+    void skipsDraftsAndPrereleasesByDefault() throws Exception {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.github.com/repos/example/demo/releases",
+                """
+                        [
+                          {
+                            "id": 1,
+                            "tag_name": "v1.0.0",
+                            "draft": false,
+                            "prerelease": false,
+                            "published_at": "2023-09-10T10:00:00Z",
+                            "assets": [
+                              { "browser_download_url": "https://example.com/v1.0.0.jar" }
+                            ]
+                          },
+                          {
+                            "id": 2,
+                            "tag_name": "v1.1.0-beta",
+                            "draft": false,
+                            "prerelease": true,
+                            "published_at": "2023-09-12T10:00:00Z",
+                            "assets": [
+                              { "browser_download_url": "https://example.com/v1.1.0-beta.jar" }
+                            ]
+                          },
+                          {
+                            "id": 3,
+                            "tag_name": "v1.0.1",
+                            "draft": false,
+                            "prerelease": false,
+                            "published_at": "2023-09-11T10:00:00Z",
+                            "assets": [
+                              { "browser_download_url": "https://example.com/v1.0.1.jar" }
+                            ]
+                          },
+                          {
+                            "id": 4,
+                            "tag_name": "v0.9.9",
+                            "draft": true,
+                            "prerelease": false,
+                            "published_at": "2023-09-13T10:00:00Z",
+                            "assets": [
+                              { "browser_download_url": "https://example.com/v0.9.9.jar" }
+                            ]
+                          }
+                        ]
+                        """);
+
+        GithubReleaseFetcher fetcher = new GithubReleaseFetcher(options(false, null), new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("v1.0.1", fetcher.getLatestVersion());
+        assertEquals(3, fetcher.getLatestBuild());
+        assertEquals("https://example.com/v1.0.1.jar", fetcher.getLatestDownloadUrl());
+    }
+
+    @Test
+    void allowsPrereleasesWhenConfigured() throws Exception {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.github.com/repos/example/demo/releases",
+                """
+                        [
+                          {
+                            "id": 10,
+                            "tag_name": "v2.0.0-beta1",
+                            "draft": false,
+                            "prerelease": true,
+                            "published_at": "2023-09-20T10:00:00Z",
+                            "assets": [
+                              { "browser_download_url": "https://example.com/v2.0.0-beta1.jar" }
+                            ]
+                          },
+                          {
+                            "id": 9,
+                            "tag_name": "v1.9.0",
+                            "draft": false,
+                            "prerelease": false,
+                            "published_at": "2023-09-18T10:00:00Z",
+                            "assets": [
+                              { "browser_download_url": "https://example.com/v1.9.0.jar" }
+                            ]
+                          }
+                        ]
+                        """);
+
+        GithubReleaseFetcher fetcher = new GithubReleaseFetcher(options(true, null), new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("v2.0.0-beta1", fetcher.getLatestVersion());
+        assertEquals(10, fetcher.getLatestBuild());
+        assertEquals("https://example.com/v2.0.0-beta1.jar", fetcher.getLatestDownloadUrl());
+    }
+
+    @Test
+    void appliesAssetPatternFilter() throws Exception {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.github.com/repos/example/demo/releases",
+                """
+                        [
+                          {
+                            "id": 5,
+                            "tag_name": "v1.2.3",
+                            "draft": false,
+                            "prerelease": false,
+                            "published_at": "2023-09-15T10:00:00Z",
+                            "assets": [
+                              { "browser_download_url": "https://example.com/v1.2.3.zip" },
+                              { "browser_download_url": "https://example.com/v1.2.3-paper.jar" }
+                            ]
+                          }
+                        ]
+                        """);
+
+        GithubReleaseFetcher matchingFetcher = new GithubReleaseFetcher(options(false, ".*-paper\\.jar$"), new StubHttpClient(responses));
+        matchingFetcher.loadLatestBuildInfo();
+        assertEquals("https://example.com/v1.2.3-paper.jar", matchingFetcher.getLatestDownloadUrl());
+
+        GithubReleaseFetcher failingFetcher = new GithubReleaseFetcher(options(false, ".*linux\\.jar$"), new StubHttpClient(responses));
+        assertThrows(IOException.class, failingFetcher::loadLatestBuildInfo);
+    }
+
+    private MemoryConfiguration options(boolean allowPrerelease, String assetPattern) {
+        MemoryConfiguration configuration = new MemoryConfiguration();
+        configuration.set("owner", "example");
+        configuration.set("repository", "demo");
+        configuration.set("allowPrerelease", allowPrerelease);
+        if (assetPattern != null) {
+            configuration.set("assetPattern", assetPattern);
+        }
+        return configuration;
+    }
+
+    private static class StubHttpClient extends HttpClient {
+        private final Map<String, String> responses;
+
+        StubHttpClient(Map<String, String> responses) {
+            super(java.net.http.HttpClient.newBuilder().build(), Duration.ofSeconds(1), Map.of());
+            this.responses = responses;
+        }
+
+        @Override
+        protected String doGet(String url) throws IOException {
+            String response = responses.get(url);
+            if (response == null) {
+                throw new IOException("No stubbed response for " + url);
+            }
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a GitHub release-backed fetcher that filters drafts/prereleases and selects matching assets
- allow optionally reading the installed plugin version via Bukkit when configured
- document githubRelease configuration options and cover the fetcher with JSON-driven unit tests

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd0b5b0c8483228a9efcbf19d148cb