### PR TITLE
Add configurable Modrinth fetcher and refactor Geyser fetcher

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/GeyserFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/GeyserFetcher.java
@@ -1,24 +1,14 @@
 package eu.nurkert.neverUp2Late.fetcher;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import eu.nurkert.neverUp2Late.net.HttpClient;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Locale;
-import java.util.OptionalInt;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Fetcher for Geyser builds using the Modrinth API.
  */
-public class GeyserFetcher extends JsonUpdateFetcher {
+public class GeyserFetcher extends ModrinthFetcher {
 
-    private static final String API_URL = "https://api.modrinth.com/v2/project/geyser/version";
     private static final Set<String> SUPPORTED_LOADERS = Set.of("paper", "spigot");
 
     public GeyserFetcher() {
@@ -26,68 +16,10 @@ public class GeyserFetcher extends JsonUpdateFetcher {
     }
 
     GeyserFetcher(HttpClient httpClient) {
-        super(httpClient);
-    }
-
-    @Override
-    public void loadLatestBuildInfo() throws Exception {
-        List<VersionResponse> versions = getJson(API_URL, new TypeReference<>() {});
-
-        List<VersionResponse> listedVersions = versions.stream()
-                .filter(version -> "listed".equalsIgnoreCase(version.status()))
-                .collect(Collectors.toList());
-
-        String latestMinecraftVersion = findLatestVersion(listedVersions.stream()
-                        .flatMap(version -> version.gameVersions().stream())
-                        .collect(Collectors.toSet()))
-                .orElseThrow(() -> new IOException("No Minecraft versions available"));
-
-        VersionResponse latestBuild = listedVersions.stream()
-                .filter(version -> version.gameVersions().contains(latestMinecraftVersion))
-                .filter(version -> version.loaders().stream().map(loader -> loader.toLowerCase(Locale.ROOT))
-                        .anyMatch(SUPPORTED_LOADERS::contains))
-                .max(Comparator.comparing(VersionResponse::datePublished))
-                .orElseThrow(() -> new IOException("No builds available for version " + latestMinecraftVersion));
-
-        OptionalInt buildNumber = extractBuildNumber(latestBuild.versionNumber());
-        if (buildNumber.isEmpty()) {
-            throw new IOException("Unable to determine build number from version " + latestBuild.versionNumber());
-        }
-
-        String downloadUrl = latestBuild.files().stream()
-                .sorted(Comparator.comparing(GeyserFile::primary).reversed())
-                .map(GeyserFile::url)
-                .filter(url -> url != null && !url.isBlank())
-                .findFirst()
-                .orElseThrow(() -> new IOException("No download available for version " + latestBuild.versionNumber()));
-
-        setLatestBuildInfo(latestBuild.versionNumber(), buildNumber.getAsInt(), downloadUrl);
-    }
-
-    @Override
-    public String getInstalledVersion() {
-        return null;
-    }
-
-    private record VersionResponse(
-            @JsonProperty("id") String id,
-            @JsonProperty("version_number") String versionNumber,
-            @JsonProperty("status") String status,
-            @JsonProperty("date_published") Instant datePublished,
-            @JsonProperty("game_versions") List<String> gameVersions,
-            @JsonProperty("loaders") List<String> loaders,
-            @JsonProperty("files") List<GeyserFile> files
-    ) {
-        private VersionResponse {
-            gameVersions = gameVersions == null ? List.of() : List.copyOf(gameVersions);
-            loaders = loaders == null ? List.of() : List.copyOf(loaders);
-            files = files == null ? List.of() : List.copyOf(files);
-        }
-    }
-
-    private record GeyserFile(
-            @JsonProperty("url") String url,
-            @JsonProperty("primary") boolean primary
-    ) {
+        super(ModrinthFetcher.builder("geyser")
+                        .loaders(SUPPORTED_LOADERS)
+                        .requireBuildNumber(true)
+                        .build(),
+                httpClient);
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/ModrinthFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/ModrinthFetcher.java
@@ -1,0 +1,354 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import eu.nurkert.neverUp2Late.net.HttpClient;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Generic Modrinth fetcher that can retrieve the latest build for any project.
+ */
+public class ModrinthFetcher extends JsonUpdateFetcher {
+
+    private static final String API_TEMPLATE = "https://api.modrinth.com/v2/project/%s/version";
+
+    private final String apiUrl;
+    private final Set<String> supportedLoaders;
+    private final Set<String> allowedStatuses;
+    private final Set<String> allowedVersionTypes;
+    private final Set<String> preferredGameVersions;
+    private final boolean preferPrimaryFile;
+    private final boolean requireBuildNumber;
+    private final String installedPluginName;
+
+    public ModrinthFetcher(ConfigurationSection options) {
+        this(Config.fromConfiguration(options));
+    }
+
+    public ModrinthFetcher(Config config) {
+        this(config, new HttpClient());
+    }
+
+    ModrinthFetcher(Config config, HttpClient httpClient) {
+        super(httpClient);
+        Objects.requireNonNull(config, "config");
+
+        this.apiUrl = String.format(API_TEMPLATE, config.projectSlug);
+        this.supportedLoaders = config.supportedLoaders;
+        this.allowedStatuses = config.allowedStatuses;
+        this.allowedVersionTypes = config.allowedVersionTypes;
+        this.preferredGameVersions = config.preferredGameVersions;
+        this.preferPrimaryFile = config.preferPrimaryFile;
+        this.requireBuildNumber = config.requireBuildNumber;
+        this.installedPluginName = config.installedPluginName;
+    }
+
+    @Override
+    public void loadLatestBuildInfo() throws Exception {
+        List<VersionResponse> versions = getJson(apiUrl, new TypeReference<>() {});
+        if (versions == null || versions.isEmpty()) {
+            throw new IOException("No versions returned for " + apiUrl);
+        }
+
+        List<VersionResponse> eligible = versions.stream()
+                .filter(version -> allowedStatuses.isEmpty() ||
+                        allowedStatuses.contains(normalize(version.status())))
+                .filter(version -> allowedVersionTypes.isEmpty() ||
+                        allowedVersionTypes.contains(normalize(version.versionType())))
+                .collect(Collectors.toList());
+
+        if (eligible.isEmpty()) {
+            throw new IOException("No versions matched the configured criteria for " + apiUrl);
+        }
+
+        String targetGameVersion = determineTargetGameVersion(eligible);
+
+        VersionResponse latestBuild = eligible.stream()
+                .filter(version -> matchesLoader(version, supportedLoaders))
+                .filter(version -> matchesGameVersion(version, targetGameVersion))
+                .max(Comparator
+                        .comparing(ModrinthFetcher::publishedAtOrMin)
+                        .thenComparing(VersionResponse::versionNumber, semanticVersionComparator()))
+                .orElseThrow(() -> new IOException("No builds available" +
+                        (targetGameVersion != null ? " for game version " + targetGameVersion : "")));
+
+        int buildNumber = resolveBuildNumber(latestBuild);
+        String downloadUrl = resolveDownloadUrl(latestBuild);
+
+        setLatestBuildInfo(latestBuild.versionNumber(), buildNumber, downloadUrl);
+    }
+
+    @Override
+    public String getInstalledVersion() {
+        if (installedPluginName == null || installedPluginName.isBlank()) {
+            return null;
+        }
+
+        PluginManager pluginManager = Bukkit.getPluginManager();
+        if (pluginManager == null) {
+            return null;
+        }
+
+        Plugin plugin = pluginManager.getPlugin(installedPluginName);
+        if (plugin == null) {
+            return null;
+        }
+
+        return plugin.getDescription().getVersion();
+    }
+
+    private String determineTargetGameVersion(Collection<VersionResponse> versions) throws IOException {
+        if (preferredGameVersions.isEmpty()) {
+            Set<String> available = versions.stream()
+                    .flatMap(version -> version.gameVersions().stream())
+                    .map(ModrinthFetcher::normalize)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+            if (available.isEmpty()) {
+                return null;
+            }
+            return requireLatestVersion(available);
+        }
+
+        Set<String> matching = versions.stream()
+                .flatMap(version -> version.gameVersions().stream())
+                .map(ModrinthFetcher::normalize)
+                .filter(preferredGameVersions::contains)
+                .collect(Collectors.toSet());
+
+        if (matching.isEmpty()) {
+            throw new IOException("No game versions available matching preferences " + preferredGameVersions);
+        }
+
+        return requireLatestVersion(matching);
+    }
+
+    private int resolveBuildNumber(VersionResponse version) throws IOException {
+        OptionalInt buildNumber = extractBuildNumber(version.versionNumber());
+        if (buildNumber.isPresent()) {
+            return buildNumber.getAsInt();
+        }
+
+        if (requireBuildNumber) {
+            throw new IOException("Unable to determine build number from version " + version.versionNumber());
+        }
+
+        int hash = Objects.hash(version.id(), version.versionNumber());
+        if (hash == Integer.MIN_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return Math.abs(hash);
+    }
+
+    private String resolveDownloadUrl(VersionResponse version) throws IOException {
+        Comparator<ModrinthFile> comparator = Comparator
+                .comparing(ModrinthFile::primary)
+                .reversed();
+
+        Supplier<IOException> exceptionSupplier = () ->
+                new IOException("No download available for version " + version.versionNumber());
+
+        return (preferPrimaryFile
+                ? version.files().stream().sorted(comparator)
+                : version.files().stream())
+                .map(ModrinthFile::url)
+                .map(ModrinthFetcher::trimToNull)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(exceptionSupplier);
+    }
+
+    private static boolean matchesLoader(VersionResponse version, Set<String> supportedLoaders) {
+        if (supportedLoaders.isEmpty()) {
+            return true;
+        }
+        return version.loaders().stream()
+                .map(ModrinthFetcher::normalize)
+                .anyMatch(supportedLoaders::contains);
+    }
+
+    private static boolean matchesGameVersion(VersionResponse version, String gameVersion) {
+        if (gameVersion == null) {
+            return true;
+        }
+        return version.gameVersions().stream()
+                .map(ModrinthFetcher::normalize)
+                .anyMatch(gameVersion::equals);
+    }
+
+    private static Instant publishedAtOrMin(VersionResponse version) {
+        Instant publishedAt = version.datePublished();
+        return publishedAt != null ? publishedAt : Instant.MIN;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed.toLowerCase(Locale.ROOT);
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private record VersionResponse(
+            @JsonProperty("id") String id,
+            @JsonProperty("version_number") String versionNumber,
+            @JsonProperty("status") String status,
+            @JsonProperty("version_type") String versionType,
+            @JsonProperty("date_published") Instant datePublished,
+            @JsonProperty("game_versions") List<String> gameVersions,
+            @JsonProperty("loaders") List<String> loaders,
+            @JsonProperty("files") List<ModrinthFile> files
+    ) {
+        private VersionResponse {
+            gameVersions = gameVersions == null ? List.of() : List.copyOf(gameVersions);
+            loaders = loaders == null ? List.of() : List.copyOf(loaders);
+            files = files == null ? List.of() : List.copyOf(files);
+        }
+    }
+
+    private record ModrinthFile(
+            @JsonProperty("url") String url,
+            @JsonProperty("primary") boolean primary
+    ) implements Comparable<ModrinthFile> {
+        @Override
+        public int compareTo(ModrinthFile other) {
+            return Boolean.compare(this.primary, other.primary);
+        }
+    }
+
+    public static ConfigBuilder builder(String projectSlug) {
+        return new ConfigBuilder(projectSlug);
+    }
+
+    public static final class Config {
+        private final String projectSlug;
+        private final Set<String> supportedLoaders;
+        private final Set<String> allowedStatuses;
+        private final Set<String> allowedVersionTypes;
+        private final Set<String> preferredGameVersions;
+        private final boolean preferPrimaryFile;
+        private final boolean requireBuildNumber;
+        private final String installedPluginName;
+
+        private Config(ConfigBuilder builder) {
+            this.projectSlug = Objects.requireNonNull(trimToNull(builder.projectSlug), "projectSlug");
+            this.supportedLoaders = builder.supportedLoaders;
+            this.allowedStatuses = builder.allowedStatuses;
+            this.allowedVersionTypes = builder.allowedVersionTypes;
+            this.preferredGameVersions = builder.preferredGameVersions;
+            this.preferPrimaryFile = builder.preferPrimaryFile;
+            this.requireBuildNumber = builder.requireBuildNumber;
+            this.installedPluginName = trimToNull(builder.installedPluginName);
+        }
+
+        public static Config fromConfiguration(ConfigurationSection options) {
+            Objects.requireNonNull(options, "options");
+
+            ConfigBuilder builder = builder(requireOption(options, "project"));
+            builder.loaders(options.getStringList("loaders"));
+            builder.statuses(options.getStringList("statuses"));
+            builder.versionTypes(options.getStringList("versionTypes"));
+            builder.gameVersions(options.getStringList("gameVersions"));
+            builder.preferPrimaryFile(options.getBoolean("preferPrimaryFile", true));
+            builder.requireBuildNumber(options.getBoolean("requireBuildNumber", false));
+            builder.installedPlugin(options.getString("installedPlugin"));
+            return builder.build();
+        }
+
+        private static String requireOption(ConfigurationSection section, String key) {
+            String value = trimToNull(section.getString(key));
+            if (value == null) {
+                throw new IllegalArgumentException("Missing required option '" + key + "'");
+            }
+            return value;
+        }
+    }
+
+    public static final class ConfigBuilder {
+        private final String projectSlug;
+        private Set<String> supportedLoaders = Set.of();
+        private Set<String> allowedStatuses = Set.of("listed");
+        private Set<String> allowedVersionTypes = Set.of();
+        private Set<String> preferredGameVersions = Set.of();
+        private boolean preferPrimaryFile = true;
+        private boolean requireBuildNumber = false;
+        private String installedPluginName;
+
+        private ConfigBuilder(String projectSlug) {
+            this.projectSlug = projectSlug;
+        }
+
+        public ConfigBuilder loaders(Collection<String> loaders) {
+            this.supportedLoaders = normalizeToSet(loaders, true);
+            return this;
+        }
+
+        public ConfigBuilder statuses(Collection<String> statuses) {
+            this.allowedStatuses = normalizeToSet(statuses, true);
+            return this;
+        }
+
+        public ConfigBuilder versionTypes(Collection<String> versionTypes) {
+            this.allowedVersionTypes = normalizeToSet(versionTypes, true);
+            return this;
+        }
+
+        public ConfigBuilder gameVersions(Collection<String> gameVersions) {
+            this.preferredGameVersions = normalizeToSet(gameVersions, true);
+            return this;
+        }
+
+        public ConfigBuilder preferPrimaryFile(boolean preferPrimaryFile) {
+            this.preferPrimaryFile = preferPrimaryFile;
+            return this;
+        }
+
+        public ConfigBuilder requireBuildNumber(boolean requireBuildNumber) {
+            this.requireBuildNumber = requireBuildNumber;
+            return this;
+        }
+
+        public ConfigBuilder installedPlugin(String installedPlugin) {
+            this.installedPluginName = installedPlugin;
+            return this;
+        }
+
+        public Config build() {
+            return new Config(this);
+        }
+
+        private static Set<String> normalizeToSet(Collection<String> values, boolean toLowerCase) {
+            if (values == null || values.isEmpty()) {
+                return Set.of();
+            }
+            return values.stream()
+                    .map(ModrinthFetcher::trimToNull)
+                    .filter(Objects::nonNull)
+                    .map(value -> toLowerCase ? value.toLowerCase(Locale.ROOT) : value)
+                    .collect(Collectors.collectingAndThen(Collectors.toSet(), Set::copyOf));
+        }
+    }
+}

--- a/src/test/java/eu/nurkert/neverUp2Late/fetcher/ModrinthFetcherTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/fetcher/ModrinthFetcherTest.java
@@ -1,0 +1,126 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import eu.nurkert.neverUp2Late.net.HttpClient;
+import org.bukkit.configuration.MemoryConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ModrinthFetcherTest {
+
+    @Test
+    void selectsLatestBuildAndFallsBackToHashForBuildNumber() throws Exception {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.modrinth.com/v2/project/example/version",
+                """
+                        [
+                          {
+                            \"id\": \"1\",
+                            \"version_number\": \"1.0.0\",
+                            \"status\": \"listed\",
+                            \"date_published\": \"2023-09-10T10:15:30Z\",
+                            \"game_versions\": [\"1.20\"],
+                            \"loaders\": [\"paper\"],
+                            \"files\": [
+                              { \"url\": \"https://example.com/1.0.0.jar\", \"primary\": false }
+                            ]
+                          },
+                          {
+                            \"id\": \"2\",
+                            \"version_number\": \"1.1.0\",
+                            \"status\": \"listed\",
+                            \"date_published\": \"2023-09-12T10:15:30Z\",
+                            \"game_versions\": [\"1.20\"],
+                            \"loaders\": [\"paper\"],
+                            \"files\": [
+                              { \"url\": \"https://example.com/1.1.0.jar\", \"primary\": true }
+                            ]
+                          }
+                        ]
+                        """);
+
+        ModrinthFetcher.Config config = ModrinthFetcher.builder("example")
+                .loaders(List.of("paper"))
+                .build();
+        ModrinthFetcher fetcher = new ModrinthFetcher(config, new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("1.1.0", fetcher.getLatestVersion());
+        assertEquals("https://example.com/1.1.0.jar", fetcher.getLatestDownloadUrl());
+
+        int hash = Objects.hash("2", "1.1.0");
+        int expectedBuild = hash == Integer.MIN_VALUE ? Integer.MAX_VALUE : Math.abs(hash);
+        assertEquals(expectedBuild, fetcher.getLatestBuild());
+        assertTrue(expectedBuild > 0);
+    }
+
+    @Test
+    void respectsPreferredGameVersionsFromConfiguration() throws Exception {
+        Map<String, String> responses = new HashMap<>();
+        responses.put("https://api.modrinth.com/v2/project/example/version",
+                """
+                        [
+                          {
+                            \"id\": \"1\",
+                            \"version_number\": \"1.1.0\",
+                            \"status\": \"listed\",
+                            \"date_published\": \"2023-09-12T10:15:30Z\",
+                            \"game_versions\": [\"1.20\"],
+                            \"loaders\": [\"paper\"],
+                            \"files\": [
+                              { \"url\": \"https://example.com/1.1.0.jar\", \"primary\": true }
+                            ]
+                          },
+                          {
+                            \"id\": \"2\",
+                            \"version_number\": \"0.9.0\",
+                            \"status\": \"listed\",
+                            \"date_published\": \"2023-08-10T10:15:30Z\",
+                            \"game_versions\": [\"1.19\"],
+                            \"loaders\": [\"paper\"],
+                            \"files\": [
+                              { \"url\": \"https://example.com/0.9.0.jar\", \"primary\": true }
+                            ]
+                          }
+                        ]
+                        """);
+
+        MemoryConfiguration options = new MemoryConfiguration();
+        options.set("project", "example");
+        options.set("loaders", List.of("paper"));
+        options.set("gameVersions", List.of("1.19"));
+
+        ModrinthFetcher.Config config = ModrinthFetcher.Config.fromConfiguration(options);
+        ModrinthFetcher fetcher = new ModrinthFetcher(config, new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("0.9.0", fetcher.getLatestVersion());
+        assertEquals("https://example.com/0.9.0.jar", fetcher.getLatestDownloadUrl());
+    }
+
+    private static class StubHttpClient extends HttpClient {
+        private final Map<String, String> responses;
+
+        StubHttpClient(Map<String, String> responses) {
+            super(java.net.http.HttpClient.newBuilder().build(), Duration.ofSeconds(1), Map.of());
+            this.responses = responses;
+        }
+
+        @Override
+        protected String doGet(String url) throws IOException {
+            String response = responses.get(url);
+            if (response == null) {
+                throw new IOException("No stubbed response for " + url);
+            }
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable `ModrinthFetcher` that works with arbitrary Modrinth projects, optional loader and status filters, and plugin version reporting
- refactor `GeyserFetcher` to delegate to the generic Modrinth implementation so existing behaviour stays intact
- add unit tests covering the generic fetcher including build number fallback and game version preferences

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68dd0b8c27588322a89c832b318543ab