### PR TITLE
Add CurseForge update fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ Projects hosted on [Hangar](https://hangar.papermc.io/) can be tracked by settin
         installedPlugin: ExamplePlugin # optional, used to detect the installed version
 ```
 
+### CurseForge sources
+
+To download updates from [CurseForge](https://www.curseforge.com/) set the source `type` to `curseforge` and provide the numeric project id in the `options`. The fetcher can optionally filter by supported Minecraft versions or include beta builds when desired:
+
+```yaml
+    - name: examplePlugin
+      type: curseforge
+      target: plugins
+      filename: "ExamplePlugin.jar"
+      options:
+        modId: 123456
+        apiKey: "your-api-key"         # optional, but recommended for higher rate limits
+        gameVersions: ["1.20.1"]        # optional list of accepted Minecraft versions
+        releaseTypes: ["release"]       # optional, defaults to ["release"], can include "beta" or "alpha"
+        installedPlugin: ExamplePlugin  # optional, used to detect the installed version
+```
+
 ### GitHub release sources
 
 To track releases that are published on GitHub, set the source `type` to `githubRelease` and provide the repository details inside the `options` block:

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/CurseforgeFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/CurseforgeFetcher.java
@@ -1,0 +1,503 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import eu.nurkert.neverUp2Late.net.HttpClient;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.Set;
+
+/**
+ * Fetcher for projects hosted on CurseForge.
+ */
+public class CurseforgeFetcher extends JsonUpdateFetcher {
+
+    private static final String API_TEMPLATE = "https://api.curseforge.com/v1/mods/%d/files?pageSize=%d&index=%d";
+    private static final int FILE_STATUS_APPROVED = 4;
+
+    private final Config config;
+
+    public CurseforgeFetcher(ConfigurationSection options) {
+        this(Config.fromConfiguration(options));
+    }
+
+    public CurseforgeFetcher(Config config) {
+        this(config, createHttpClient(config));
+    }
+
+    CurseforgeFetcher(Config config, HttpClient httpClient) {
+        super(httpClient);
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    private static HttpClient createHttpClient(Config config) {
+        if (config.apiKey() == null) {
+            return new HttpClient();
+        }
+        return new HttpClient(Map.of("x-api-key", config.apiKey()));
+    }
+
+    @Override
+    public void loadLatestBuildInfo() throws Exception {
+        Comparator<CurseforgeFile> comparator = Comparator
+                .comparing(CurseforgeFile::fileDate, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparingInt(this::releasePriority)
+                .thenComparingLong(CurseforgeFile::id);
+
+        CurseforgeFile best = null;
+        int index = 0;
+        int pagesFetched = 0;
+
+        while (pagesFetched < config.maxPages()) {
+            FilesResponse response = getJson(String.format(API_TEMPLATE,
+                    config.modId(),
+                    config.pageSize(),
+                    index), FilesResponse.class);
+
+            List<CurseforgeFile> files = response != null ? response.data() : null;
+            if (files == null || files.isEmpty()) {
+                break;
+            }
+
+            for (CurseforgeFile file : files) {
+                if (!isEligible(file)) {
+                    continue;
+                }
+                if (best == null || comparator.compare(file, best) > 0) {
+                    best = file;
+                }
+            }
+
+            pagesFetched++;
+            Pagination pagination = response.pagination();
+            if (pagination == null) {
+                break;
+            }
+
+            index += config.pageSize();
+            if (pagination.totalCount() > 0 && index >= pagination.totalCount()) {
+                break;
+            }
+        }
+
+        if (best == null) {
+            throw new IOException("No suitable CurseForge file found for mod " + config.modId());
+        }
+
+        String downloadUrl = trimToNull(best.downloadUrl());
+        if (downloadUrl == null) {
+            throw new IOException("Selected CurseForge file " + best.id() + " does not have a download URL");
+        }
+
+        String version = resolveVersion(best);
+        int buildNumber = resolveBuildNumber(best);
+
+        setLatestBuildInfo(version, buildNumber, downloadUrl);
+    }
+
+    @Override
+    public String getInstalledVersion() {
+        String pluginName = config.installedPluginName();
+        if (pluginName == null || pluginName.isBlank()) {
+            return null;
+        }
+
+        PluginManager pluginManager = Bukkit.getPluginManager();
+        if (pluginManager == null) {
+            return null;
+        }
+
+        Plugin plugin = pluginManager.getPlugin(pluginName);
+        if (plugin == null) {
+            return null;
+        }
+
+        return plugin.getDescription().getVersion();
+    }
+
+    private boolean isEligible(CurseforgeFile file) {
+        if (file == null) {
+            return false;
+        }
+
+        if (file.fileStatus() != FILE_STATUS_APPROVED) {
+            return false;
+        }
+
+        ReleaseType releaseType = ReleaseType.fromId(file.releaseType());
+        if (releaseType == null || !config.allowedReleaseTypes().contains(releaseType)) {
+            return false;
+        }
+
+        if (!config.preferredGameVersions().isEmpty() && !matchesPreferredGameVersion(file)) {
+            return false;
+        }
+
+        if (!config.gameVersionTypeIds().isEmpty() && !matchesGameVersionType(file)) {
+            return false;
+        }
+
+        return trimToNull(file.downloadUrl()) != null;
+    }
+
+    private boolean matchesPreferredGameVersion(CurseforgeFile file) {
+        for (String version : safeList(file.gameVersions())) {
+            String normalized = normalizeGameVersion(version);
+            if (normalized != null && config.preferredGameVersions().contains(normalized)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesGameVersionType(CurseforgeFile file) {
+        for (SortableGameVersion sortable : safeList(file.sortableGameVersions())) {
+            Integer typeId = sortable.gameVersionTypeId();
+            if (typeId != null && config.gameVersionTypeIds().contains(typeId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int releasePriority(CurseforgeFile file) {
+        ReleaseType releaseType = ReleaseType.fromId(file.releaseType());
+        return releaseType != null ? releaseType.priority() : 0;
+    }
+
+    private String resolveVersion(CurseforgeFile file) {
+        String displayName = trimToNull(file.displayName());
+        if (displayName != null) {
+            return displayName;
+        }
+
+        String fileName = trimToNull(file.fileName());
+        if (fileName != null) {
+            return fileName;
+        }
+
+        return Long.toString(file.id());
+    }
+
+    private int resolveBuildNumber(CurseforgeFile file) {
+        OptionalInt buildNumber = extractBuildNumber(trimToNull(file.displayName()));
+        if (buildNumber.isEmpty()) {
+            buildNumber = extractBuildNumber(trimToNull(file.fileName()));
+        }
+        if (buildNumber.isPresent()) {
+            return buildNumber.getAsInt();
+        }
+
+        long id = file.id();
+        if (id >= 0 && id <= Integer.MAX_VALUE) {
+            return (int) id;
+        }
+
+        int hash = Objects.hash(file.id(), file.fileName());
+        if (hash == Integer.MIN_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return Math.abs(hash);
+    }
+
+    private static String normalizeGameVersion(String value) {
+        String trimmed = trimToNull(value);
+        return trimmed != null ? trimmed.toLowerCase(Locale.ROOT) : null;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static <T> List<T> safeList(List<T> values) {
+        return values != null ? values : List.of();
+    }
+
+    public static ConfigBuilder builder(long modId) {
+        return new ConfigBuilder(modId);
+    }
+
+    public static final class Config {
+        private final long modId;
+        private final String apiKey;
+        private final int pageSize;
+        private final int maxPages;
+        private final Set<String> preferredGameVersions;
+        private final Set<Integer> gameVersionTypeIds;
+        private final EnumSet<ReleaseType> allowedReleaseTypes;
+        private final String installedPluginName;
+
+        private Config(ConfigBuilder builder) {
+            if (builder.modId <= 0) {
+                throw new IllegalArgumentException("CurseForge modId must be positive");
+            }
+            this.modId = builder.modId;
+            this.apiKey = trimToNull(builder.apiKey);
+            this.pageSize = builder.pageSize;
+            this.maxPages = builder.maxPages;
+            this.preferredGameVersions = builder.preferredGameVersions;
+            this.gameVersionTypeIds = builder.gameVersionTypeIds;
+            this.allowedReleaseTypes = builder.allowedReleaseTypes.isEmpty()
+                    ? EnumSet.of(ReleaseType.RELEASE)
+                    : EnumSet.copyOf(builder.allowedReleaseTypes);
+            this.installedPluginName = trimToNull(builder.installedPluginName);
+        }
+
+        public static Config fromConfiguration(ConfigurationSection options) {
+            Objects.requireNonNull(options, "options");
+
+            long modId = options.getLong("modId");
+            if (modId <= 0) {
+                throw new IllegalArgumentException("CurseForge fetcher requires a positive 'modId'");
+            }
+
+            ConfigBuilder builder = builder(modId);
+            builder.apiKey(options.getString("apiKey"));
+            builder.pageSize(options.getInt("pageSize", builder.pageSize));
+            builder.maxPages(options.getInt("maxPages", builder.maxPages));
+            if (options.contains("gameVersions")) {
+                builder.gameVersions(options.getStringList("gameVersions"));
+            }
+            if (options.contains("gameVersionTypeIds")) {
+                builder.gameVersionTypeIds(options.getIntegerList("gameVersionTypeIds"));
+            }
+            if (options.contains("releaseTypes")) {
+                builder.releaseTypes(options.getStringList("releaseTypes"));
+            }
+            builder.installedPlugin(options.getString("installedPlugin"));
+            return builder.build();
+        }
+
+        public long modId() {
+            return modId;
+        }
+
+        public String apiKey() {
+            return apiKey;
+        }
+
+        public int pageSize() {
+            return pageSize;
+        }
+
+        public int maxPages() {
+            return maxPages;
+        }
+
+        public Set<String> preferredGameVersions() {
+            return preferredGameVersions;
+        }
+
+        public Set<Integer> gameVersionTypeIds() {
+            return gameVersionTypeIds;
+        }
+
+        public Set<ReleaseType> allowedReleaseTypes() {
+            return allowedReleaseTypes;
+        }
+
+        public String installedPluginName() {
+            return installedPluginName;
+        }
+    }
+
+    public static final class ConfigBuilder {
+        private final long modId;
+        private String apiKey;
+        private int pageSize = 50;
+        private int maxPages = 1;
+        private Set<String> preferredGameVersions = Set.of();
+        private Set<Integer> gameVersionTypeIds = Set.of();
+        private EnumSet<ReleaseType> allowedReleaseTypes = EnumSet.of(ReleaseType.RELEASE);
+        private String installedPluginName;
+
+        private ConfigBuilder(long modId) {
+            this.modId = modId;
+        }
+
+        public ConfigBuilder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public ConfigBuilder pageSize(int pageSize) {
+            if (pageSize > 0) {
+                this.pageSize = pageSize;
+            }
+            return this;
+        }
+
+        public ConfigBuilder maxPages(int maxPages) {
+            if (maxPages > 0) {
+                this.maxPages = maxPages;
+            }
+            return this;
+        }
+
+        public ConfigBuilder gameVersions(Collection<String> versions) {
+            this.preferredGameVersions = copyGameVersions(versions);
+            return this;
+        }
+
+        public ConfigBuilder gameVersionTypeIds(Collection<Integer> typeIds) {
+            this.gameVersionTypeIds = copyIntegers(typeIds);
+            return this;
+        }
+
+        public ConfigBuilder releaseTypes(Collection<String> releaseTypes) {
+            if (releaseTypes == null || releaseTypes.isEmpty()) {
+                this.allowedReleaseTypes = EnumSet.of(ReleaseType.RELEASE);
+            } else {
+                EnumSet<ReleaseType> parsed = EnumSet.noneOf(ReleaseType.class);
+                for (String value : releaseTypes) {
+                    ReleaseType releaseType = ReleaseType.fromConfig(value);
+                    if (releaseType != null) {
+                        parsed.add(releaseType);
+                    }
+                }
+                if (parsed.isEmpty()) {
+                    parsed.add(ReleaseType.RELEASE);
+                }
+                this.allowedReleaseTypes = parsed;
+            }
+            return this;
+        }
+
+        public ConfigBuilder releaseTypesEnum(Collection<ReleaseType> releaseTypes) {
+            if (releaseTypes == null || releaseTypes.isEmpty()) {
+                this.allowedReleaseTypes = EnumSet.of(ReleaseType.RELEASE);
+            } else {
+                this.allowedReleaseTypes = EnumSet.copyOf(releaseTypes);
+            }
+            return this;
+        }
+
+        public ConfigBuilder installedPlugin(String pluginName) {
+            this.installedPluginName = pluginName;
+            return this;
+        }
+
+        public Config build() {
+            if (allowedReleaseTypes == null || allowedReleaseTypes.isEmpty()) {
+                allowedReleaseTypes = EnumSet.of(ReleaseType.RELEASE);
+            }
+            if (pageSize <= 0) {
+                pageSize = 50;
+            }
+            if (maxPages <= 0) {
+                maxPages = 1;
+            }
+            return new Config(this);
+        }
+    }
+
+    private static Set<String> copyGameVersions(Collection<String> versions) {
+        if (versions == null || versions.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String version : versions) {
+            String normalizedVersion = normalizeGameVersion(version);
+            if (normalizedVersion != null) {
+                normalized.add(normalizedVersion);
+            }
+        }
+        return normalized.isEmpty() ? Set.of() : Set.copyOf(normalized);
+    }
+
+    private static Set<Integer> copyIntegers(Collection<Integer> values) {
+        if (values == null || values.isEmpty()) {
+            return Set.of();
+        }
+        Set<Integer> result = new LinkedHashSet<>();
+        for (Integer value : values) {
+            if (value != null && value > 0) {
+                result.add(value);
+            }
+        }
+        return result.isEmpty() ? Set.of() : Set.copyOf(result);
+    }
+
+    private enum ReleaseType {
+        RELEASE(1, 3, "release"),
+        BETA(2, 2, "beta"),
+        ALPHA(3, 1, "alpha");
+
+        private final int id;
+        private final int priority;
+        private final String configName;
+
+        ReleaseType(int id, int priority, String configName) {
+            this.id = id;
+            this.priority = priority;
+            this.configName = configName;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public int priority() {
+            return priority;
+        }
+
+        public static ReleaseType fromId(int id) {
+            for (ReleaseType type : values()) {
+                if (type.id == id) {
+                    return type;
+                }
+            }
+            return null;
+        }
+
+        public static ReleaseType fromConfig(String value) {
+            if (value == null) {
+                return null;
+            }
+            String normalized = value.trim().toLowerCase(Locale.ROOT);
+            for (ReleaseType type : values()) {
+                if (type.configName.equals(normalized) || Integer.toString(type.id).equals(normalized)) {
+                    return type;
+                }
+            }
+            return null;
+        }
+    }
+
+    private record FilesResponse(List<CurseforgeFile> data, Pagination pagination) {
+    }
+
+    private record Pagination(int index, int pageSize, int resultCount, int totalCount) {
+    }
+
+    private record CurseforgeFile(@JsonProperty("id") long id,
+                                  @JsonProperty("displayName") String displayName,
+                                  @JsonProperty("fileName") String fileName,
+                                  @JsonProperty("releaseType") int releaseType,
+                                  @JsonProperty("fileStatus") int fileStatus,
+                                  @JsonProperty("downloadUrl") String downloadUrl,
+                                  @JsonProperty("fileDate") Instant fileDate,
+                                  @JsonProperty("gameVersions") List<String> gameVersions,
+                                  @JsonProperty("sortableGameVersions") List<SortableGameVersion> sortableGameVersions) {
+    }
+
+    private record SortableGameVersion(@JsonProperty("gameVersionTypeId") Integer gameVersionTypeId) {
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
@@ -31,10 +31,37 @@ public class HttpClient {
                 DEFAULT_HEADERS);
     }
 
+    /**
+     * Creates a new HTTP client that includes the provided headers in addition to the defaults.
+     *
+     * @param additionalHeaders headers that should be sent with every request
+     */
+    public HttpClient(Map<String, String> additionalHeaders) {
+        this(java.net.http.HttpClient.newBuilder()
+                        .connectTimeout(DEFAULT_CONNECT_TIMEOUT)
+                        .build(),
+                DEFAULT_REQUEST_TIMEOUT,
+                mergeHeaders(additionalHeaders));
+    }
+
     protected HttpClient(java.net.http.HttpClient client, Duration requestTimeout, Map<String, String> defaultHeaders) {
         this.client = Objects.requireNonNull(client, "client");
         this.requestTimeout = Objects.requireNonNull(requestTimeout, "requestTimeout");
         this.defaultHeaders = Map.copyOf(defaultHeaders);
+    }
+
+    private static Map<String, String> mergeHeaders(Map<String, String> additionalHeaders) {
+        if (additionalHeaders == null || additionalHeaders.isEmpty()) {
+            return DEFAULT_HEADERS;
+        }
+
+        Map<String, String> merged = new java.util.LinkedHashMap<>(DEFAULT_HEADERS);
+        for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                merged.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return Map.copyOf(merged);
     }
 
     /**

--- a/src/test/java/eu/nurkert/neverUp2Late/fetcher/CurseforgeFetcherTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/fetcher/CurseforgeFetcherTest.java
@@ -1,0 +1,146 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import eu.nurkert.neverUp2Late.net.HttpClient;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CurseforgeFetcherTest {
+
+    @Test
+    void selectsLatestApprovedFileMatchingGameVersions() throws Exception {
+        Map<String, String> responses = Map.of(
+                "https://api.curseforge.com/v1/mods/12345/files?pageSize=50&index=0",
+                """
+                        {
+                          \"data\": [
+                            {
+                              \"id\": 2000,
+                              \"displayName\": \"Plugin 1.1.0\",
+                              \"fileName\": \"plugin-1.1.0.jar\",
+                              \"releaseType\": 1,
+                              \"fileStatus\": 4,
+                              \"downloadUrl\": \"https://example.com/plugin-1.1.0.jar\",
+                              \"fileDate\": \"2024-01-10T10:00:00Z\",
+                              \"gameVersions\": [\"1.20\"],
+                              \"sortableGameVersions\": [
+                                { \"gameVersionTypeId\": 73250 }
+                              ]
+                            },
+                            {
+                              \"id\": 2001,
+                              \"displayName\": \"Plugin 1.2.0\",
+                              \"fileName\": \"plugin-1.2.0.jar\",
+                              \"releaseType\": 1,
+                              \"fileStatus\": 4,
+                              \"downloadUrl\": \"https://example.com/plugin-1.2.0.jar\",
+                              \"fileDate\": \"2024-02-05T12:00:00Z\",
+                              \"gameVersions\": [\"1.20.1\"],
+                              \"sortableGameVersions\": [
+                                { \"gameVersionTypeId\": 73250 }
+                              ]
+                            },
+                            {
+                              \"id\": 2002,
+                              \"displayName\": \"Plugin 1.2.1\",
+                              \"fileName\": \"plugin-1.2.1.jar\",
+                              \"releaseType\": 1,
+                              \"fileStatus\": 4,
+                              \"downloadUrl\": \"https://example.com/plugin-1.2.1.jar\",
+                              \"fileDate\": \"2024-03-01T12:00:00Z\",
+                              \"gameVersions\": [\"1.19.4\"],
+                              \"sortableGameVersions\": [
+                                { \"gameVersionTypeId\": 73250 }
+                              ]
+                            }
+                          ],
+                          \"pagination\": {
+                            \"index\": 0,
+                            \"pageSize\": 50,
+                            \"resultCount\": 3,
+                            \"totalCount\": 3
+                          }
+                        }
+                        """);
+
+        CurseforgeFetcher.Config config = CurseforgeFetcher.builder(12345)
+                .gameVersions(List.of("1.20.1"))
+                .build();
+        CurseforgeFetcher fetcher = new CurseforgeFetcher(config, new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("Plugin 1.2.0", fetcher.getLatestVersion());
+        assertEquals("https://example.com/plugin-1.2.0.jar", fetcher.getLatestDownloadUrl());
+        assertEquals(2001, fetcher.getLatestBuild());
+    }
+
+    @Test
+    void respectsReleaseTypePreferences() throws Exception {
+        Map<String, String> responses = Map.of(
+                "https://api.curseforge.com/v1/mods/54321/files?pageSize=25&index=0",
+                """
+                        {
+                          \"data\": [
+                            {
+                              \"id\": 3000,
+                              \"displayName\": \"Plugin 1.2.0\",
+                              \"fileName\": \"plugin-1.2.0.jar\",
+                              \"releaseType\": 1,
+                              \"fileStatus\": 4,
+                              \"downloadUrl\": \"https://example.com/plugin-1.2.0.jar\",
+                              \"fileDate\": \"2024-01-01T00:00:00Z\"
+                            },
+                            {
+                              \"id\": 3001,
+                              \"displayName\": \"Plugin 1.3.0-b42\",
+                              \"fileName\": \"plugin-1.3.0-b42.jar\",
+                              \"releaseType\": 2,
+                              \"fileStatus\": 4,
+                              \"downloadUrl\": \"https://example.com/plugin-1.3.0-b42.jar\",
+                              \"fileDate\": \"2024-02-20T00:00:00Z\"
+                            }
+                          ],
+                          \"pagination\": {
+                            \"index\": 0,
+                            \"pageSize\": 25,
+                            \"resultCount\": 2,
+                            \"totalCount\": 2
+                          }
+                        }
+                        """);
+
+        CurseforgeFetcher.Config config = CurseforgeFetcher.builder(54321)
+                .pageSize(25)
+                .releaseTypes(List.of("release", "Beta"))
+                .build();
+        CurseforgeFetcher fetcher = new CurseforgeFetcher(config, new StubHttpClient(responses));
+        fetcher.loadLatestBuildInfo();
+
+        assertEquals("Plugin 1.3.0-b42", fetcher.getLatestVersion());
+        assertEquals("https://example.com/plugin-1.3.0-b42.jar", fetcher.getLatestDownloadUrl());
+        assertEquals(42, fetcher.getLatestBuild());
+    }
+
+    private static class StubHttpClient extends HttpClient {
+        private final Map<String, String> responses;
+
+        StubHttpClient(Map<String, String> responses) {
+            super(java.net.http.HttpClient.newBuilder().build(), Duration.ofSeconds(1), Map.of());
+            this.responses = responses;
+        }
+
+        @Override
+        protected String doGet(String url) throws IOException {
+            String response = responses.get(url);
+            if (response == null) {
+                throw new IOException("No stubbed response for " + url);
+            }
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable HttpClient constructor so fetchers can supply custom headers
- implement a new CurseForge update fetcher with filtering for game versions, release types, and optional Bukkit integration
- document CurseForge usage and cover the fetcher with unit tests

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd1270829c8322b0071e49f2c2265b