### PR TITLE
Shade Jackson dependencies for runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,22 @@
                     <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Summary
- add the Maven Shade plugin so Jackson dependencies are packaged with the plugin jar

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd1c6fb4608322a9d819b0835538f5