### PR TITLE
Fix GitHub release fetcher JSON parsing to avoid classloader error

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
@@ -1,7 +1,6 @@
 package eu.nurkert.neverUp2Late.fetcher;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import eu.nurkert.neverUp2Late.net.HttpClient;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -46,8 +45,9 @@ public class GithubReleaseFetcher extends JsonUpdateFetcher {
 
     @Override
     public void loadLatestBuildInfo() throws Exception {
-        List<Release> releases = getJson(buildUrl(), new TypeReference<>() {});
-        if (releases == null || releases.isEmpty()) {
+        Release[] releaseArray = getJson(buildUrl(), Release[].class);
+        List<Release> releases = releaseArray != null ? List.of(releaseArray) : List.of();
+        if (releases.isEmpty()) {
             throw new IOException("No releases returned for " + owner + "/" + repository);
         }
 


### PR DESCRIPTION
## Summary
- replace the anonymous TypeReference used for GitHub release parsing with array-based deserialization to avoid classloader access to closed plugin jars

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd1db567108322994ed696ecc431bf