### PR TITLE
Allow choosing GitHub assets for quick install

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ To track releases that are published on GitHub, set the source `type` to `github
 
 If `assetPattern` is omitted the first asset with a download URL is used. When `installedPlugin` is configured the fetcher queries Bukkit's `PluginManager` to determine the installed version, otherwise it returns `null`.
 
+When using the `/nu2l install <url>` command you can control which GitHub asset is selected by appending query parameters to the release URL. `?asset=<text>` matches assets whose download URL contains the provided text (case-insensitive) while `?assetPattern=<regex>` accepts a full regular expression. Direct download links created from the "Download" buttons are also recognized and will automatically prefer the referenced asset on future updates.
+
 ### Jenkins sources
 
 Self-hosted Jenkins instances can be queried by setting the source `type` to `jenkins`. Provide the base URL of the Jenkins instance and the job path (folders can be separated with `/`). When multiple artifacts are published you can either specify the exact `artifact` file name or a regular expression via `artifactPattern`.

--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class QuickInstallCoordinator {
 
@@ -296,7 +297,16 @@ public class QuickInstallCoordinator {
         Map<String, Object> options = new LinkedHashMap<>();
         options.put("owner", owner);
         options.put("repository", repository);
-        options.put("assetPattern", "(?i).*\\.jar$");
+
+        Map<String, String> parameters = new LinkedHashMap<>();
+        parameters.putAll(parseParameters(uri.getRawQuery()));
+        parameters.putAll(parseParameters(uri.getRawFragment()));
+
+        String assetPattern = determineGithubAssetPattern(segments, parameters);
+        if (assetPattern == null || assetPattern.isBlank()) {
+            assetPattern = "(?i).*\\.jar$";
+        }
+        options.put("assetPattern", assetPattern);
 
         InstallationPlan plan = new InstallationPlan(
                 originalUrl,
@@ -432,6 +442,64 @@ public class QuickInstallCoordinator {
         return segments;
     }
 
+    private Map<String, String> parseParameters(String raw) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        if (raw == null || raw.isBlank()) {
+            return parameters;
+        }
+        for (String pair : raw.split("&")) {
+            if (pair.isBlank()) {
+                continue;
+            }
+            int separator = pair.indexOf('=');
+            String key;
+            String value;
+            if (separator >= 0) {
+                key = pair.substring(0, separator);
+                value = pair.substring(separator + 1);
+            } else {
+                key = pair;
+                value = "";
+            }
+            key = decode(key).trim();
+            value = decode(value).trim();
+            if (!key.isEmpty() && !parameters.containsKey(key)) {
+                parameters.put(key, value);
+            }
+        }
+        return parameters;
+    }
+
+    private String determineGithubAssetPattern(List<String> segments, Map<String, String> parameters) {
+        String explicitPattern = trimToNull(parameters.get("assetPattern"));
+        if (explicitPattern != null) {
+            return explicitPattern;
+        }
+
+        String assetName = trimToNull(parameters.get("asset"));
+        if (assetName != null) {
+            return buildSubstringPattern(assetName);
+        }
+
+        if (segments.size() >= 4 && "releases".equalsIgnoreCase(segments.get(2))
+                && "download".equalsIgnoreCase(segments.get(3)) && segments.size() >= 5) {
+            String filename = segments.get(segments.size() - 1);
+            if (!filename.isBlank() && filename.contains(".")) {
+                return buildExactFilenamePattern(filename);
+            }
+        }
+
+        return null;
+    }
+
+    private String buildSubstringPattern(String assetName) {
+        return "(?i).*" + Pattern.quote(assetName) + ".*";
+    }
+
+    private String buildExactFilenamePattern(String filename) {
+        return "(?i).*" + Pattern.quote(filename) + "$";
+    }
+
     private String decode(String value) {
         return URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
@@ -453,6 +521,14 @@ public class QuickInstallCoordinator {
             end--;
         }
         return value.substring(start, end);
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private String toDisplayName(String slug) {


### PR DESCRIPTION
## Summary
- allow the quick install flow to derive an asset pattern from GitHub release URLs via query parameters or direct download links
- document how to select GitHub assets when using the quick install command

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd289c83548322a08c5a246b3341f8