### PR TITLE
Comment out placeholder GitHub source in default config

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,13 +29,15 @@ updates:
       target: plugins
       filename: "Geyser-Spigot.jar"
 
-    - name: examplePlugin
-      type: githubRelease
-      target: plugins
-      filename: "ExamplePlugin.jar"
-      options:
-        owner: example
-        repository: example-plugin
-        # assetPattern: ".*paper.*\\.jar$"   # optional regex to select a specific asset
-        # allowPrerelease: false              # optional, defaults to false
-        # installedPlugin: "ExamplePlugin"   # optional, used to read the installed version
+    # The example below illustrates how to configure a GitHub release source.
+    # Uncomment and adjust the values to track a real project.
+    # - name: examplePlugin
+    #   type: githubRelease
+    #   target: plugins
+    #   filename: "ExamplePlugin.jar"
+    #   options:
+    #     owner: example
+    #     repository: example-plugin
+    #     # assetPattern: ".*paper.*\\.jar$"   # optional regex to select a specific asset
+    #     # allowPrerelease: false              # optional, defaults to false
+    #     # installedPlugin: "ExamplePlugin"   # optional, used to read the installed version


### PR DESCRIPTION
## Summary
- comment out the placeholder GitHub release source in the default configuration so it no longer triggers update attempts

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd33145c08832293d635f24ad08438