### PR TITLE
Ensure Paper fetcher skips experimental releases

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcher.java
@@ -5,8 +5,12 @@ import eu.nurkert.neverUp2Late.net.HttpClient;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Fetcher for Paper builds using the PaperMC public API.
@@ -14,6 +18,7 @@ import java.util.List;
 public class PaperFetcher extends JsonUpdateFetcher {
 
     private static final String API_URL = "https://api.papermc.io/v2/projects/paper";
+    private static final Set<String> STABLE_CHANNELS = Set.of("default", "stable");
 
     private final boolean fetchStableVersions;
 
@@ -45,14 +50,34 @@ public class PaperFetcher extends JsonUpdateFetcher {
         if (fetchStableVersions) {
             versions = filterStableVersions(versions);
         }
-        String latestVersion = requireLatestVersion(versions);
+        if (versions.isEmpty()) {
+            throw new IOException("No versions available");
+        }
 
-        VersionResponse versionResponse = getJson(API_URL + "/versions/" + latestVersion, VersionResponse.class);
-        int latestBuild = selectLatestBuild(versionResponse.builds());
-        String downloadUrl = API_URL + "/versions/" + latestVersion + "/builds/" + latestBuild
-                + "/downloads/paper-" + latestVersion + "-" + latestBuild + ".jar";
+        versions.sort(semanticVersionComparator().reversed());
 
-        setLatestBuildInfo(latestVersion, latestBuild, downloadUrl);
+        Exception lastError = null;
+        for (String version : versions) {
+            try {
+                VersionResponse versionResponse = getJson(API_URL + "/versions/" + version, VersionResponse.class);
+                int latestBuild = fetchStableVersions
+                        ? selectLatestStableBuild(version, versionResponse.builds())
+                        : selectLatestBuild(versionResponse.builds());
+                String downloadUrl = API_URL + "/versions/" + version + "/builds/" + latestBuild
+                        + "/downloads/paper-" + version + "-" + latestBuild + ".jar";
+
+                setLatestBuildInfo(version, latestBuild, downloadUrl);
+                return;
+            } catch (Exception exception) {
+                lastError = exception;
+            }
+        }
+
+        if (lastError != null) {
+            throw lastError;
+        }
+
+        throw new IOException("No suitable builds available");
     }
 
     @Override
@@ -75,6 +100,34 @@ public class PaperFetcher extends JsonUpdateFetcher {
         private VersionResponse {
             builds = builds == null ? List.of() : List.copyOf(builds);
         }
+    }
+
+    private record BuildResponse(@JsonProperty("channel") String channel) {
+    }
+
+    private int selectLatestStableBuild(String version, List<Integer> builds) throws IOException {
+        if (builds.isEmpty()) {
+            throw new IOException("No builds available for version " + version);
+        }
+
+        List<Integer> sortedBuilds = new ArrayList<>(builds);
+        sortedBuilds.sort(Comparator.reverseOrder());
+
+        for (Integer build : sortedBuilds) {
+            BuildResponse buildResponse = getJson(API_URL + "/versions/" + version + "/builds/" + build, BuildResponse.class);
+            if (isStableChannel(buildResponse.channel())) {
+                return build;
+            }
+        }
+
+        throw new IOException("No stable builds available for version " + version);
+    }
+
+    private boolean isStableChannel(String channel) {
+        if (channel == null) {
+            return true;
+        }
+        return STABLE_CHANNELS.contains(channel.toLowerCase(Locale.ROOT));
     }
 
     private static boolean determineStablePreference(ConfigurationSection options) {


### PR DESCRIPTION
## Summary
- update the Paper fetcher to consider build channels when selecting the latest version
- skip experimental Paper builds and fall back to the newest available stable release

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd3581da008322be709531250868c9