### PR TITLE
Add missing Paper build stub responses for tests

### DIFF
--- a/src/test/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcherTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/fetcher/PaperFetcherTest.java
@@ -29,6 +29,12 @@ class PaperFetcherTest {
                           "builds": [14, 15, 16]
                         }
                         """);
+        responses.put("https://api.papermc.io/v2/projects/paper/versions/1.20.1/builds/16",
+                """
+                        {
+                          "channel": "default"
+                        }
+                        """);
 
         PaperFetcher fetcher = new PaperFetcher(true, new StubHttpClient(responses));
         fetcher.loadLatestBuildInfo();
@@ -90,6 +96,12 @@ class PaperFetcherTest {
                 """
                         {
                           "builds": [15, 16]
+                        }
+                        """);
+        responses.put("https://api.papermc.io/v2/projects/paper/versions/1.20.1/builds/16",
+                """
+                        {
+                          "channel": "stable"
                         }
                         """);
 


### PR DESCRIPTION
## Summary
- add stubbed PaperMC build responses so PaperFetcher tests can resolve channel data

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68dd36a7b1e48322afe4f1eff55ebf62