### PR TITLE
Add hourly cooldown for automatic server restarts

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/handlers/InstallationHandler.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/handlers/InstallationHandler.java
@@ -7,8 +7,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 public class InstallationHandler implements Listener, UpdateCompletionListener {
@@ -60,6 +62,8 @@ public class InstallationHandler implements Listener, UpdateCompletionListener {
 
     public static class ServerRestartAction implements PostUpdateAction {
         private final Server server;
+        private static final long RESTART_COOLDOWN_MILLIS = Duration.ofHours(1).toMillis();
+        private static final AtomicLong LAST_RESTART_TIME = new AtomicLong(0L);
 
         public ServerRestartAction(Server server) {
             this.server = server;
@@ -67,6 +71,34 @@ public class InstallationHandler implements Listener, UpdateCompletionListener {
 
         @Override
         public void execute(UpdateCompletedEvent event) {
+            long now = System.currentTimeMillis();
+
+            while (true) {
+                long lastRestart = LAST_RESTART_TIME.get();
+                long elapsed = now - lastRestart;
+
+                if (lastRestart != 0L && elapsed < RESTART_COOLDOWN_MILLIS) {
+                    long remainingMillis = RESTART_COOLDOWN_MILLIS - elapsed;
+                    Duration remaining = Duration.ofMillis(remainingMillis);
+                    long minutes = remaining.toMinutes();
+                    long seconds = remaining.minusMinutes(minutes).getSeconds();
+
+                    server.getLogger().log(
+                            Level.INFO,
+                            String.format(
+                                    "Skipping server restart; cooldown active for %d minute(s) and %d second(s).",
+                                    minutes,
+                                    seconds
+                            )
+                    );
+                    return;
+                }
+
+                if (LAST_RESTART_TIME.compareAndSet(lastRestart, now)) {
+                    break;
+                }
+            }
+
             server.shutdown();
         }
 


### PR DESCRIPTION
## Summary
- add an hourly cooldown guard to the automatic server restart action
- log a message when a restart is skipped because the cooldown is active

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd3fd45f1883228d82aef2e7599428