### PR TITLE
Add interactive GitHub asset selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To track releases that are published on GitHub, set the source `type` to `github
         installedPlugin: "ExamplePlugin"    # optional, used to detect the currently installed version
 ```
 
-If `assetPattern` is omitted the first asset with a download URL is used. When `installedPlugin` is configured the fetcher queries Bukkit's `PluginManager` to determine the installed version, otherwise it returns `null`.
+If `assetPattern` is omitted the fetcher will automatically select the only matching JAR asset. When multiple matching assets are available, the quick install command now lists all candidates and lets you choose the correct file via `/nu2l select <nummer>`. A suitable regular expression is generated automatically from your selection and stored for future updates. Archive downloads such as `.zip` files keep their original extension so you can extract the contained JAR manually when necessary. When `installedPlugin` is configured the fetcher queries Bukkit's `PluginManager` to determine the installed version, otherwise it returns `null`.
 
 ### Jenkins sources
 

--- a/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
@@ -25,8 +25,17 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
+        if (args.length > 0 && "select".equalsIgnoreCase(args[0])) {
+            if (args.length < 2) {
+                sender.sendMessage(ChatColor.RED + "Bitte gib die Nummer der gewünschten Datei an.");
+                return true;
+            }
+            coordinator.handleAssetSelection(sender, args[1]);
+            return true;
+        }
+
         if (args.length == 0) {
-            sender.sendMessage(ChatColor.RED + "Verwendung: /" + label + " <url>");
+            sender.sendMessage(ChatColor.RED + "Verwendung: /" + label + " <url> oder /" + label + " select <nummer>");
             return true;
         }
 

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/AssetPatternBuilder.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/AssetPatternBuilder.java
@@ -1,0 +1,41 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility to create resilient regular expressions for GitHub release assets
+ * based on a concrete asset name chosen by the user.
+ */
+public final class AssetPatternBuilder {
+
+    private static final Pattern VERSION_TOKEN = Pattern.compile("\\d+(?:[._+-]\\d+)*");
+
+    private AssetPatternBuilder() {
+    }
+
+    public static String build(String assetName) {
+        String value = Objects.requireNonNull(assetName, "assetName");
+        value = value.trim();
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException("assetName must not be blank");
+        }
+
+        Matcher matcher = VERSION_TOKEN.matcher(value);
+        StringBuilder builder = new StringBuilder("(?i)^");
+        int lastEnd = 0;
+        while (matcher.find()) {
+            if (matcher.start() > lastEnd) {
+                builder.append(Pattern.quote(value.substring(lastEnd, matcher.start())));
+            }
+            builder.append("\\d+(?:[._+-]\\d+)*");
+            lastEnd = matcher.end();
+        }
+        if (lastEnd < value.length()) {
+            builder.append(Pattern.quote(value.substring(lastEnd)));
+        }
+        builder.append('$');
+        return builder.toString();
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/exception/AssetSelectionRequiredException.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/exception/AssetSelectionRequiredException.java
@@ -1,0 +1,63 @@
+package eu.nurkert.neverUp2Late.fetcher.exception;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Exception indicating that a release contains multiple matching assets and a
+ * manual selection is required to proceed.
+ */
+public class AssetSelectionRequiredException extends Exception {
+
+    private final String releaseTag;
+    private final List<ReleaseAsset> assets;
+    private final AssetType assetType;
+
+    public AssetSelectionRequiredException(String releaseTag,
+                                            List<ReleaseAsset> assets,
+                                            AssetType assetType) {
+        super(buildMessage(releaseTag, assetType, assets));
+        this.releaseTag = releaseTag;
+        this.assets = List.copyOf(assets);
+        this.assetType = assetType;
+    }
+
+    public String getReleaseTag() {
+        return releaseTag;
+    }
+
+    public List<ReleaseAsset> getAssets() {
+        return assets;
+    }
+
+    public AssetType getAssetType() {
+        return assetType;
+    }
+
+    private static String buildMessage(String releaseTag, AssetType assetType, List<ReleaseAsset> assets) {
+        String typeLabel = assetType == null ? "asset" : assetType.displayName();
+        return "Multiple " + typeLabel + " candidates for release " + releaseTag + ": " + assets.size();
+    }
+
+    public enum AssetType {
+        JAR("JAR"),
+        ARCHIVE("Archive"),
+        UNKNOWN("Asset");
+
+        private final String displayName;
+
+        AssetType(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String displayName() {
+            return displayName;
+        }
+    }
+
+    public record ReleaseAsset(String name, String downloadUrl, boolean archive) {
+        public ReleaseAsset {
+            Objects.requireNonNull(downloadUrl, "downloadUrl");
+        }
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
@@ -17,7 +17,11 @@ public class HttpClient {
 
     private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(10);
-    private static final Map<String, String> DEFAULT_HEADERS = Map.of("User-Agent", "never-up-2-late/1.0");
+    private static final Map<String, String> DEFAULT_HEADERS = Map.of(
+            "User-Agent", "never-up-2-late/1.0",
+            "Accept", "application/vnd.github+json",
+            "X-GitHub-Api-Version", "2022-11-28"
+    );
 
     private final java.net.http.HttpClient client;
     private final Duration requestTimeout;

--- a/src/test/java/eu/nurkert/neverUp2Late/fetcher/AssetPatternBuilderTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/fetcher/AssetPatternBuilderTest.java
@@ -1,0 +1,33 @@
+package eu.nurkert.neverUp2Late.fetcher;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AssetPatternBuilderTest {
+
+    @Test
+    void buildsRegexThatKeepsStaticPartsAndReplacesVersions() {
+        String pattern = AssetPatternBuilder.build("DynamicLights-Paper-1.20.6.jar");
+
+        assertTrue(pattern.startsWith("(?i)"));
+        Pattern compiled = Pattern.compile(pattern);
+        assertTrue(compiled.matcher("DynamicLights-Paper-1.21.0.jar").matches());
+        assertFalse(compiled.matcher("DynamicLights-Folia-1.21.0.jar").matches());
+    }
+
+    @Test
+    void keepsArchiveExtension() {
+        String pattern = AssetPatternBuilder.build("demo-1.4.0.zip");
+        Pattern compiled = Pattern.compile(pattern);
+        assertTrue(compiled.matcher("demo-1.5.0.zip").matches());
+        assertFalse(compiled.matcher("demo-1.5.0.jar").matches());
+    }
+
+    @Test
+    void rejectsBlankInput() {
+        assertThrows(IllegalArgumentException.class, () -> AssetPatternBuilder.build("   "));
+    }
+}


### PR DESCRIPTION
## Summary
- add an interactive selection flow for ambiguous GitHub assets, including the `/nu2l select` command and pending selection handling
- update the GitHub release fetcher to detect jar and archive assets, keep archive extensions, and raise explicit selection exceptions
- add an asset pattern builder utility with unit tests and document the selection workflow in the README

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd3e3cb9188322ba73048fd4cead9f