### PR TITLE
Avoid generic filenames for Hangar downloads

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -46,6 +46,19 @@ public class QuickInstallCoordinator {
     private final Logger logger;
     private final String messagePrefix;
     private final Map<String, PendingSelection> pendingSelections = new ConcurrentHashMap<>();
+    private static final Set<String> GENERIC_FILENAMES = Set.of(
+            "download",
+            "latest",
+            "paper",
+            "spigot",
+            "folia",
+            "velocity",
+            "waterfall",
+            "bungeecord",
+            "purpur",
+            "server",
+            "plugin"
+    );
 
     public QuickInstallCoordinator(PluginContext context) {
         this.plugin = context.getPlugin();
@@ -478,6 +491,14 @@ public class QuickInstallCoordinator {
             }
             if (!candidate.contains(".")) {
                 candidate = candidate + ".jar";
+            }
+            String candidateBase = candidate;
+            int dotIndex = candidateBase.indexOf('.');
+            if (dotIndex > 0) {
+                candidateBase = candidateBase.substring(0, dotIndex);
+            }
+            if (GENERIC_FILENAMES.contains(candidateBase.toLowerCase(Locale.ROOT))) {
+                return fallback;
             }
             return candidate;
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- treat known placeholder filenames from Hangar downloads as generic values
- fall back to the generated plugin slug when a placeholder filename is detected

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd450d0788832286d8afac366dac31