### PR TITLE
Respect configured default filenames for quick installs

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 # The names of the jars as they are in the server directory
 filenames:
   geyser: "Geyser-Spigot.jar"
+  floodgate: "floodgate-spigot.jar"
   paper: "paper.jar"
 
 # Check interval in minutes


### PR DESCRIPTION
## Summary
- allow quick installs from Hangar, Modrinth, GitHub, and Jenkins to fall back to configured default filenames
- add a default filename mapping for the Floodgate plugin so its jar keeps the floodgate-spigot suffix

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd46d2fb18832299ce6fae3d446c8e