### PR TITLE
Persist restart cooldown across restarts

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -22,7 +22,7 @@ public final class NeverUp2Late extends JavaPlugin {
         FileConfiguration configuration = getConfig();
 
         PersistentPluginHandler persistentPluginHandler = new PersistentPluginHandler(this);
-        InstallationHandler installationHandler = new InstallationHandler(getServer());
+        InstallationHandler installationHandler = new InstallationHandler(this);
         UpdateSourceRegistry updateSourceRegistry = new UpdateSourceRegistry(getLogger(), configuration);
         ArtifactDownloader artifactDownloader = new ArtifactDownloader();
         VersionComparator versionComparator = new VersionComparator();

--- a/src/main/java/eu/nurkert/neverUp2Late/persistence/RestartCooldownRepository.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/persistence/RestartCooldownRepository.java
@@ -1,0 +1,62 @@
+package eu.nurkert.neverUp2Late.persistence;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RestartCooldownRepository {
+
+    private static final String FILE_NAME = "restart-state.yml";
+    private static final String LAST_RESTART_NODE = "lastRestartTime";
+
+    private final File stateFile;
+    private final Logger logger;
+    private FileConfiguration configuration;
+
+    public RestartCooldownRepository(File dataFolder, Logger logger) {
+        this.logger = logger;
+        this.stateFile = new File(dataFolder, FILE_NAME);
+        initialise(dataFolder);
+    }
+
+    private void initialise(File dataFolder) {
+        ensureDataFolderExists(dataFolder);
+        ensureStateFileExists();
+        configuration = YamlConfiguration.loadConfiguration(stateFile);
+    }
+
+    private void ensureDataFolderExists(File dataFolder) {
+        if (!dataFolder.exists() && !dataFolder.mkdirs()) {
+            logger.log(Level.WARNING, "Could not create plugin data folder at {0}", dataFolder.getAbsolutePath());
+        }
+    }
+
+    private void ensureStateFileExists() {
+        if (!stateFile.exists()) {
+            try {
+                if (!stateFile.createNewFile()) {
+                    logger.log(Level.WARNING, "Unable to create {0}", stateFile.getAbsolutePath());
+                }
+            } catch (IOException e) {
+                logger.log(Level.SEVERE, "Failed to create " + FILE_NAME, e);
+            }
+        }
+    }
+
+    public synchronized long getLastRestartTime() {
+        return configuration.getLong(LAST_RESTART_NODE, 0L);
+    }
+
+    public synchronized void saveLastRestartTime(long timestamp) {
+        configuration.set(LAST_RESTART_NODE, timestamp);
+        try {
+            configuration.save(stateFile);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to persist last restart time", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- persist the server restart cooldown so update restarts only happen once per hour even across JVM restarts
- log when the server restart is skipped or triggered during post-update handling
- extend installation handler tests to cover the cooldown persistence behaviour

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68dd4724be2c8322b0d2e57b3c66fd8d