### PR TITLE
Default HTTP client to accept JSON and scope GitHub headers

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -26,6 +27,10 @@ import java.util.Locale;
 public class GithubReleaseFetcher extends JsonUpdateFetcher {
 
     private static final String API_TEMPLATE = "https://api.github.com/repos/%s/%s/releases";
+    private static final Map<String, String> GITHUB_HEADERS = Map.of(
+            "Accept", "application/vnd.github+json",
+            "X-GitHub-Api-Version", "2022-11-28"
+    );
 
     private final String owner;
     private final String repository;
@@ -34,7 +39,7 @@ public class GithubReleaseFetcher extends JsonUpdateFetcher {
     private final String installedPluginName;
 
     public GithubReleaseFetcher(ConfigurationSection options) {
-        this(options, new HttpClient());
+        this(options, new HttpClient(GITHUB_HEADERS));
     }
 
     GithubReleaseFetcher(ConfigurationSection options, HttpClient httpClient) {

--- a/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
@@ -19,8 +19,7 @@ public class HttpClient {
     private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(10);
     private static final Map<String, String> DEFAULT_HEADERS = Map.of(
             "User-Agent", "never-up-2-late/1.0",
-            "Accept", "application/vnd.github+json",
-            "X-GitHub-Api-Version", "2022-11-28"
+            "Accept", "application/json"
     );
 
     private final java.net.http.HttpClient client;
@@ -52,6 +51,10 @@ public class HttpClient {
         this.client = Objects.requireNonNull(client, "client");
         this.requestTimeout = Objects.requireNonNull(requestTimeout, "requestTimeout");
         this.defaultHeaders = Map.copyOf(defaultHeaders);
+    }
+
+    protected Map<String, String> getDefaultHeaders() {
+        return defaultHeaders;
     }
 
     private static Map<String, String> mergeHeaders(Map<String, String> additionalHeaders) {


### PR DESCRIPTION
## Summary
- default the shared HTTP client to send a generic `application/json` Accept header and expose the defaults for verification
- configure the GitHub release fetcher to add its vendor-specific headers via the extensible HTTP client constructor
- update the Hangar fetcher tests to assert requests succeed when only generic JSON headers are provided

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68de6b194e548322b2199658c6f45360