### PR TITLE
Make HttpClient Accept header configurable and fix Hangar fetcher

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
@@ -39,7 +39,9 @@ public class GithubReleaseFetcher extends JsonUpdateFetcher {
     private final String installedPluginName;
 
     public GithubReleaseFetcher(ConfigurationSection options) {
-        this(options, new HttpClient(GITHUB_HEADERS));
+        this(options, HttpClient.builder()
+                .headers(GITHUB_HEADERS)
+                .build());
     }
 
     GithubReleaseFetcher(ConfigurationSection options, HttpClient httpClient) {

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/HangarFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/HangarFetcher.java
@@ -34,7 +34,9 @@ public class HangarFetcher extends JsonUpdateFetcher {
     }
 
     public HangarFetcher(Config config) {
-        this(config, new HttpClient());
+        this(config, HttpClient.builder()
+                .accept("application/json")
+                .build());
     }
 
     HangarFetcher(Config config, HttpClient httpClient) {

--- a/src/test/java/eu/nurkert/neverUp2Late/net/HttpClientTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/net/HttpClientTest.java
@@ -1,0 +1,77 @@
+package eu.nurkert.neverUp2Late.net;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HttpClientTest {
+
+    private HttpServer server;
+    private String endpointUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/versions", new ConditionalAcceptHandler());
+        server.start();
+        endpointUrl = "http://localhost:" + server.getAddress().getPort() + "/versions";
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void returns406WhenAcceptHeaderDoesNotMatchPolicy() {
+        HttpClient client = HttpClient.builder()
+                .accept("application/vnd.github+json")
+                .build();
+
+        assertThrows(HttpException.class, () -> client.get(endpointUrl));
+    }
+
+    @Test
+    void succeedsWhenAcceptHeaderMatchesPolicy() throws IOException {
+        HttpClient client = HttpClient.builder()
+                .accept("application/json")
+                .build();
+
+        String response = client.get(endpointUrl);
+        assertEquals("{\"status\":\"ok\"}", response);
+    }
+
+    private static class ConditionalAcceptHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String accept = exchange.getRequestHeaders().getFirst("Accept");
+            byte[] body;
+            int statusCode;
+            if ("application/json".equals(accept)) {
+                body = "{\"status\":\"ok\"}".getBytes(StandardCharsets.UTF_8);
+                statusCode = 200;
+            } else {
+                body = "Not acceptable".getBytes(StandardCharsets.UTF_8);
+                statusCode = 406;
+            }
+
+            exchange.sendResponseHeaders(statusCode, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a builder to HttpClient so callers can override the default Accept header policy
- update Hangar and GitHub fetchers to use the new builder and send the appropriate Accept header
- add an HTTP client test that reproduces the previous 406 response and confirms the fix

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68de6ca7412c8322bfbfe29844886396