### PR TITLE
Add plugin lifecycle manager API and integrate reload workflow

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -7,6 +7,8 @@ import eu.nurkert.neverUp2Late.handlers.ArtifactDownloader;
 import eu.nurkert.neverUp2Late.handlers.InstallationHandler;
 import eu.nurkert.neverUp2Late.handlers.PersistentPluginHandler;
 import eu.nurkert.neverUp2Late.handlers.UpdateHandler;
+import eu.nurkert.neverUp2Late.plugin.PluginLifecycleManager;
+import eu.nurkert.neverUp2Late.plugin.PluginManagerApi;
 import eu.nurkert.neverUp2Late.update.UpdateSourceRegistry;
 import eu.nurkert.neverUp2Late.update.VersionComparator;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -32,7 +34,14 @@ public final class NeverUp2Late extends JavaPlugin {
         }
 
         PersistentPluginHandler persistentPluginHandler = new PersistentPluginHandler(updateStateRepository);
-        InstallationHandler installationHandler = new InstallationHandler(this);
+        PluginLifecycleManager pluginLifecycleManager = new PluginManagerApi(
+                getServer().getPluginManager(),
+                getDataFolder().getParentFile(),
+                getLogger()
+        );
+        pluginLifecycleManager.registerLoadedPlugins(this);
+
+        InstallationHandler installationHandler = new InstallationHandler(this, pluginLifecycleManager);
         UpdateSourceRegistry updateSourceRegistry = new UpdateSourceRegistry(getLogger(), configuration);
         ArtifactDownloader artifactDownloader = new ArtifactDownloader();
         VersionComparator versionComparator = new VersionComparator();
@@ -55,7 +64,8 @@ public final class NeverUp2Late extends JavaPlugin {
                 persistentPluginHandler,
                 updateHandler,
                 installationHandler,
-                updateSourceRegistry
+                updateSourceRegistry,
+                pluginLifecycleManager
         );
 
         updateHandler.start();

--- a/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
@@ -3,6 +3,7 @@ package eu.nurkert.neverUp2Late.core;
 import eu.nurkert.neverUp2Late.handlers.InstallationHandler;
 import eu.nurkert.neverUp2Late.handlers.PersistentPluginHandler;
 import eu.nurkert.neverUp2Late.handlers.UpdateHandler;
+import eu.nurkert.neverUp2Late.plugin.PluginLifecycleManager;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -20,6 +21,7 @@ public class PluginContext {
     private final UpdateHandler updateHandler;
     private final InstallationHandler installationHandler;
     private final eu.nurkert.neverUp2Late.update.UpdateSourceRegistry updateSourceRegistry;
+    private final PluginLifecycleManager pluginLifecycleManager;
 
     public PluginContext(JavaPlugin plugin,
                          BukkitScheduler scheduler,
@@ -27,7 +29,8 @@ public class PluginContext {
                          PersistentPluginHandler persistentPluginHandler,
                          UpdateHandler updateHandler,
                          InstallationHandler installationHandler,
-                         eu.nurkert.neverUp2Late.update.UpdateSourceRegistry updateSourceRegistry) {
+                         eu.nurkert.neverUp2Late.update.UpdateSourceRegistry updateSourceRegistry,
+                         PluginLifecycleManager pluginLifecycleManager) {
         this.plugin = plugin;
         this.scheduler = scheduler;
         this.configuration = configuration;
@@ -35,6 +38,7 @@ public class PluginContext {
         this.updateHandler = updateHandler;
         this.installationHandler = installationHandler;
         this.updateSourceRegistry = updateSourceRegistry;
+        this.pluginLifecycleManager = pluginLifecycleManager;
     }
 
     public JavaPlugin getPlugin() {
@@ -63,5 +67,9 @@ public class PluginContext {
 
     public eu.nurkert.neverUp2Late.update.UpdateSourceRegistry getUpdateSourceRegistry() {
         return updateSourceRegistry;
+    }
+
+    public PluginLifecycleManager getPluginLifecycleManager() {
+        return pluginLifecycleManager;
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/plugin/BukkitManagedPlugin.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/plugin/BukkitManagedPlugin.java
@@ -1,0 +1,247 @@
+package eu.nurkert.neverUp2Late.plugin;
+
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.plugin.InvalidDescriptionException;
+import org.bukkit.plugin.InvalidPluginException;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.RegisteredListener;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Bukkit specific {@link ManagedPlugin} implementation that mirrors the
+ * behaviour of the platform's plugin loader while providing deterministic
+ * lifecycle operations.
+ */
+class BukkitManagedPlugin implements ManagedPlugin {
+
+    private final PluginManager pluginManager;
+    private final Logger logger;
+    private final Path pluginPath;
+
+    private Plugin plugin;
+    private String lastKnownName;
+
+    BukkitManagedPlugin(Plugin plugin, Path pluginPath, PluginManager pluginManager, Logger logger) {
+        this.pluginManager = pluginManager;
+        this.logger = logger;
+        this.pluginPath = pluginPath.toAbsolutePath().normalize();
+        attach(plugin);
+        if (lastKnownName == null) {
+            this.lastKnownName = deriveNameFromPath(pluginPath);
+        }
+    }
+
+    @Override
+    public synchronized void attach(Plugin plugin) {
+        this.plugin = plugin;
+        if (plugin != null) {
+            this.lastKnownName = plugin.getName();
+        }
+    }
+
+    @Override
+    public synchronized String getName() {
+        if (plugin != null) {
+            return plugin.getName();
+        }
+        return lastKnownName != null ? lastKnownName : deriveNameFromPath(pluginPath);
+    }
+
+    @Override
+    public Path getPath() {
+        return pluginPath;
+    }
+
+    @Override
+    public synchronized Optional<Plugin> getPlugin() {
+        return Optional.ofNullable(plugin);
+    }
+
+    @Override
+    public synchronized boolean isLoaded() {
+        return plugin != null;
+    }
+
+    @Override
+    public synchronized boolean isEnabled() {
+        return plugin != null && plugin.isEnabled();
+    }
+
+    @Override
+    public synchronized void load() throws PluginLifecycleException {
+        ensurePluginFileExists();
+        if (plugin != null) {
+            throw new PluginLifecycleException("Plugin " + getName() + " is already loaded");
+        }
+        try {
+            Plugin loaded = pluginManager.loadPlugin(pluginPath.toFile());
+            loaded.onLoad();
+            attach(loaded);
+        } catch (InvalidPluginException | InvalidDescriptionException ex) {
+            throw new PluginLifecycleException("Failed to load plugin from " + pluginPath + ": " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public synchronized void enable() throws PluginLifecycleException {
+        if (plugin == null) {
+            throw new PluginLifecycleException("Cannot enable plugin " + getName() + " because it is not loaded");
+        }
+        if (!plugin.isEnabled()) {
+            pluginManager.enablePlugin(plugin);
+        }
+    }
+
+    @Override
+    public synchronized void disable() throws PluginLifecycleException {
+        if (plugin == null) {
+            return;
+        }
+        if (plugin.isEnabled()) {
+            pluginManager.disablePlugin(plugin);
+        }
+    }
+
+    @Override
+    public synchronized void unload() throws PluginLifecycleException {
+        if (plugin == null) {
+            return;
+        }
+
+        Plugin existing = plugin;
+        disable();
+        removePluginFromBukkit(existing);
+        detachClassLoader(existing);
+        attach(null);
+        System.gc();
+    }
+
+    @Override
+    public synchronized void reload() throws PluginLifecycleException {
+        unload();
+        load();
+        enable();
+    }
+
+    private void ensurePluginFileExists() throws PluginLifecycleException {
+        if (!Files.exists(pluginPath)) {
+            throw new PluginLifecycleException("Plugin file does not exist: " + pluginPath);
+        }
+    }
+
+    private void removePluginFromBukkit(Plugin target) throws PluginLifecycleException {
+        try {
+            Field pluginsField = pluginManager.getClass().getDeclaredField("plugins");
+            Field lookupNamesField = pluginManager.getClass().getDeclaredField("lookupNames");
+            Field listenersField = null;
+            try {
+                listenersField = pluginManager.getClass().getDeclaredField("listeners");
+            } catch (NoSuchFieldException ignored) {
+                // Some Bukkit implementations removed this field; that's fine.
+            }
+            Field commandMapField = pluginManager.getClass().getDeclaredField("commandMap");
+
+            pluginsField.setAccessible(true);
+            lookupNamesField.setAccessible(true);
+            commandMapField.setAccessible(true);
+
+            @SuppressWarnings("unchecked")
+            List<Plugin> plugins = (List<Plugin>) pluginsField.get(pluginManager);
+            @SuppressWarnings("unchecked")
+            Map<String, Plugin> names = (Map<String, Plugin>) lookupNamesField.get(pluginManager);
+
+            if (plugins != null) {
+                plugins.remove(target);
+            }
+            if (names != null) {
+                names.values().removeIf(value -> value == target);
+            }
+
+            if (listenersField != null) {
+                listenersField.setAccessible(true);
+                @SuppressWarnings("unchecked")
+                Map<Object, SortedSet<RegisteredListener>> listeners =
+                        (Map<Object, SortedSet<RegisteredListener>>) listenersField.get(pluginManager);
+                if (listeners != null) {
+                    for (SortedSet<RegisteredListener> set : listeners.values()) {
+                        if (set == null) {
+                            continue;
+                        }
+                        Iterator<RegisteredListener> iterator = set.iterator();
+                        while (iterator.hasNext()) {
+                            RegisteredListener listener = iterator.next();
+                            if (listener.getPlugin() == target) {
+                                iterator.remove();
+                            }
+                        }
+                    }
+                }
+            }
+
+            SimpleCommandMap commandMap = (SimpleCommandMap) commandMapField.get(pluginManager);
+            if (commandMap != null) {
+                Field knownCommandsField = SimpleCommandMap.class.getDeclaredField("knownCommands");
+                knownCommandsField.setAccessible(true);
+                @SuppressWarnings("unchecked")
+                Map<String, Object> knownCommands = (Map<String, Object>) knownCommandsField.get(commandMap);
+                if (knownCommands != null) {
+                    Iterator<Map.Entry<String, Object>> iterator = knownCommands.entrySet().iterator();
+                    while (iterator.hasNext()) {
+                        Map.Entry<String, Object> entry = iterator.next();
+                        Object value = entry.getValue();
+                        if (value instanceof PluginCommand command && command.getPlugin() == target) {
+                            command.unregister(commandMap);
+                            iterator.remove();
+                        }
+                    }
+                }
+            }
+        } catch (ReflectiveOperationException ex) {
+            throw new PluginLifecycleException("Failed to cleanly unregister plugin " + getName(), ex);
+        }
+    }
+
+    private void detachClassLoader(Plugin target) throws PluginLifecycleException {
+        ClassLoader loader = target.getClass().getClassLoader();
+        if (!(loader instanceof URLClassLoader urlClassLoader)) {
+            return;
+        }
+        try {
+            Field pluginField = loader.getClass().getDeclaredField("plugin");
+            Field pluginInitField = loader.getClass().getDeclaredField("pluginInit");
+            pluginField.setAccessible(true);
+            pluginInitField.setAccessible(true);
+            pluginField.set(loader, null);
+            pluginInitField.set(loader, null);
+        } catch (ReflectiveOperationException ex) {
+            logger.log(Level.FINE, "Unable to detach plugin references from class loader", ex);
+        }
+        try {
+            urlClassLoader.close();
+        } catch (IOException ex) {
+            throw new PluginLifecycleException("Failed to close class loader for " + getName(), ex);
+        }
+    }
+
+    private String deriveNameFromPath(Path path) {
+        String fileName = path.getFileName() != null ? path.getFileName().toString() : path.toString();
+        if (fileName.endsWith(".jar")) {
+            fileName = fileName.substring(0, fileName.length() - 4);
+        }
+        return fileName;
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/plugin/ManagedPlugin.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/plugin/ManagedPlugin.java
@@ -1,0 +1,55 @@
+package eu.nurkert.neverUp2Late.plugin;
+
+import org.bukkit.plugin.Plugin;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Represents a plugin that can be controlled via the {@link PluginLifecycleManager}.
+ * Implementations wrap the underlying Bukkit plugin instance and provide
+ * lifecycle operations such as load, unload, enable and disable.
+ */
+public interface ManagedPlugin {
+
+    /**
+     * @return the last known display name of the plugin.
+     */
+    String getName();
+
+    /**
+     * @return the absolute path of the plugin JAR that is managed.
+     */
+    Path getPath();
+
+    /**
+     * Updates the managed plugin instance. Implementations should update their
+     * internal state to reflect the supplied plugin.
+     */
+    void attach(Plugin plugin);
+
+    /**
+     * @return the currently loaded Bukkit plugin, if any.
+     */
+    Optional<Plugin> getPlugin();
+
+    /**
+     * @return {@code true} if the plugin is currently loaded.
+     */
+    boolean isLoaded();
+
+    /**
+     * @return {@code true} if the plugin is enabled in Bukkit.
+     */
+    boolean isEnabled();
+
+    void load() throws PluginLifecycleException;
+
+    void enable() throws PluginLifecycleException;
+
+    void disable() throws PluginLifecycleException;
+
+    void unload() throws PluginLifecycleException;
+
+    void reload() throws PluginLifecycleException;
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/plugin/PluginLifecycleException.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/plugin/PluginLifecycleException.java
@@ -1,0 +1,17 @@
+package eu.nurkert.neverUp2Late.plugin;
+
+/**
+ * Exception raised when a plugin lifecycle operation fails. This wraps
+ * reflective access issues as well as Bukkit loader errors so callers can
+ * handle lifecycle problems uniformly.
+ */
+public class PluginLifecycleException extends Exception {
+
+    public PluginLifecycleException(String message) {
+        super(message);
+    }
+
+    public PluginLifecycleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/plugin/PluginLifecycleManager.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/plugin/PluginLifecycleManager.java
@@ -1,0 +1,44 @@
+package eu.nurkert.neverUp2Late.plugin;
+
+import org.bukkit.plugin.Plugin;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Unified management interface that exposes lifecycle operations for plugins.
+ * Implementations wrap the underlying platform specific APIs and normalise the
+ * results so callers can work against a consistent abstraction.
+ */
+public interface PluginLifecycleManager {
+
+    /**
+     * Registers an already loaded plugin with the lifecycle manager.
+     */
+    void registerPlugin(Plugin plugin);
+
+    /**
+     * Registers all currently loaded plugins with the lifecycle manager while
+     * skipping the provided reference (usually the manager plugin itself).
+     */
+    void registerLoadedPlugins(Plugin self);
+
+    Collection<ManagedPlugin> getManagedPlugins();
+
+    Optional<ManagedPlugin> findByName(String name);
+
+    Optional<ManagedPlugin> findByPath(Path path);
+
+    boolean reloadPlugin(String name) throws PluginLifecycleException;
+
+    boolean reloadPlugin(Path path) throws PluginLifecycleException;
+
+    boolean enablePlugin(String name) throws PluginLifecycleException;
+
+    boolean disablePlugin(String name) throws PluginLifecycleException;
+
+    boolean unloadPlugin(String name) throws PluginLifecycleException;
+
+    boolean loadPlugin(Path path) throws PluginLifecycleException;
+}

--- a/src/main/java/eu/nurkert/neverUp2Late/plugin/PluginManagerApi.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/plugin/PluginManagerApi.java
@@ -1,0 +1,236 @@
+package eu.nurkert.neverUp2Late.plugin;
+
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSource;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Default implementation of {@link PluginLifecycleManager}. It exposes a
+ * uniform API for managing Bukkit plugins via reflective access to the
+ * platform's internals when necessary.
+ */
+public class PluginManagerApi implements PluginLifecycleManager {
+
+    private final PluginManager pluginManager;
+    private final Path pluginsDirectory;
+    private final Logger logger;
+    private final Map<Path, ManagedPlugin> managedPlugins = new ConcurrentHashMap<>();
+
+    public PluginManagerApi(PluginManager pluginManager, File pluginsDirectory, Logger logger) {
+        this.pluginManager = Objects.requireNonNull(pluginManager, "pluginManager");
+        this.pluginsDirectory = pluginsDirectory == null
+                ? null
+                : pluginsDirectory.toPath().toAbsolutePath().normalize();
+        this.logger = logger;
+    }
+
+    @Override
+    public void registerPlugin(Plugin plugin) {
+        if (plugin == null) {
+            return;
+        }
+        resolvePluginPath(plugin).ifPresent(path -> {
+            ManagedPlugin managed = managedPlugins.get(path);
+            if (managed != null) {
+                managed.attach(plugin);
+            } else {
+                managedPlugins.put(path, new BukkitManagedPlugin(plugin, path, pluginManager, logger));
+            }
+        });
+    }
+
+    @Override
+    public void registerLoadedPlugins(Plugin self) {
+        for (Plugin plugin : pluginManager.getPlugins()) {
+            if (plugin == null || plugin.equals(self)) {
+                continue;
+            }
+            registerPlugin(plugin);
+        }
+    }
+
+    @Override
+    public Collection<ManagedPlugin> getManagedPlugins() {
+        return Collections.unmodifiableCollection(managedPlugins.values());
+    }
+
+    @Override
+    public Optional<ManagedPlugin> findByName(String name) {
+        if (name == null || name.isBlank()) {
+            return Optional.empty();
+        }
+        String normalized = name.trim();
+        return managedPlugins.values().stream()
+                .filter(plugin -> {
+                    String candidate = plugin.getName();
+                    return candidate != null && candidate.equalsIgnoreCase(normalized);
+                })
+                .findFirst();
+    }
+
+    @Override
+    public Optional<ManagedPlugin> findByPath(Path path) {
+        if (path == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(managedPlugins.get(normalize(path)));
+    }
+
+    @Override
+    public boolean reloadPlugin(String name) throws PluginLifecycleException {
+        Optional<ManagedPlugin> plugin = findByName(name);
+        if (plugin.isEmpty()) {
+            return false;
+        }
+        plugin.get().reload();
+        return true;
+    }
+
+    @Override
+    public boolean reloadPlugin(Path path) throws PluginLifecycleException {
+        ManagedPlugin managed = ensureManaged(path);
+        if (managed == null) {
+            return false;
+        }
+        managed.reload();
+        return true;
+    }
+
+    @Override
+    public boolean enablePlugin(String name) throws PluginLifecycleException {
+        Optional<ManagedPlugin> plugin = findByName(name);
+        if (plugin.isEmpty()) {
+            return false;
+        }
+        plugin.get().enable();
+        return true;
+    }
+
+    @Override
+    public boolean disablePlugin(String name) throws PluginLifecycleException {
+        Optional<ManagedPlugin> plugin = findByName(name);
+        if (plugin.isEmpty()) {
+            return false;
+        }
+        plugin.get().disable();
+        return true;
+    }
+
+    @Override
+    public boolean unloadPlugin(String name) throws PluginLifecycleException {
+        Optional<ManagedPlugin> plugin = findByName(name);
+        if (plugin.isEmpty()) {
+            return false;
+        }
+        plugin.get().unload();
+        return true;
+    }
+
+    @Override
+    public boolean loadPlugin(Path path) throws PluginLifecycleException {
+        ManagedPlugin managed = ensureManaged(path);
+        if (managed == null) {
+            return false;
+        }
+        if (managed.isLoaded()) {
+            return false;
+        }
+        managed.load();
+        managed.enable();
+        return true;
+    }
+
+    private ManagedPlugin ensureManaged(Path path) {
+        if (path == null) {
+            return null;
+        }
+        Path normalized = normalize(path);
+        ManagedPlugin managed = managedPlugins.get(normalized);
+        if (managed != null) {
+            return managed;
+        }
+        if (!Files.exists(normalized)) {
+            return null;
+        }
+        ManagedPlugin newManaged = new BukkitManagedPlugin(null, normalized, pluginManager, logger);
+        managedPlugins.put(normalized, newManaged);
+        return newManaged;
+    }
+
+    private Path normalize(Path path) {
+        return path.toAbsolutePath().normalize();
+    }
+
+    private Optional<Path> resolvePluginPath(Plugin plugin) {
+        Path fromCodeSource = resolveFromCodeSource(plugin);
+        if (fromCodeSource != null) {
+            return Optional.of(fromCodeSource);
+        }
+        if (pluginsDirectory == null) {
+            return Optional.empty();
+        }
+        String unifiedName = unify(plugin.getName());
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(pluginsDirectory, "*.jar")) {
+            for (Path entry : stream) {
+                if (unify(entry.getFileName().toString()).contains(unifiedName)) {
+                    return Optional.of(entry.toAbsolutePath().normalize());
+                }
+            }
+        } catch (IOException ex) {
+            logFine("Failed to scan plugins directory for " + plugin.getName(), ex);
+        }
+        return Optional.empty();
+    }
+
+    private Path resolveFromCodeSource(Plugin plugin) {
+        try {
+            CodeSource codeSource = plugin.getClass().getProtectionDomain().getCodeSource();
+            if (codeSource == null) {
+                return null;
+            }
+            if (codeSource.getLocation() == null) {
+                return null;
+            }
+            Path location = Path.of(codeSource.getLocation().toURI());
+            if (Files.isRegularFile(location)) {
+                return location.toAbsolutePath().normalize();
+            }
+        } catch (Exception ex) {
+            logFine("Unable to resolve plugin path from code source for " + plugin.getName(), ex);
+        }
+        return null;
+    }
+
+    private String unify(String value) {
+        if (value == null) {
+            return "";
+        }
+        String unified = value.toLowerCase(Locale.ROOT);
+        unified = unified.replace(" ", "");
+        unified = unified.replace("-", "");
+        unified = unified.replace("_", "");
+        unified = unified.replace(".", "");
+        return unified;
+    }
+
+    private void logFine(String message, Exception ex) {
+        if (logger != null) {
+            logger.log(Level.FINE, message, ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Bukkit-aware plugin lifecycle manager API with managed plugin abstraction and lifecycle exception
- wire the new manager into the plugin context and bootstrap to register loaded plugins
- update the installation handler to reload updated plugins before falling back to server restarts and cover the behaviour in tests

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68de6e55554883229c8393bd2ac6e65f