### PR TITLE
Ensure asset selection regex stays unique to chosen variant

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -147,7 +147,10 @@ public class QuickInstallCoordinator {
 
         AssetSelectionRequiredException.ReleaseAsset asset = pending.assets().get(index - 1);
         String assetName = assetLabel(asset);
-        String pattern = AssetPatternBuilder.build(assetName);
+        List<String> candidateNames = pending.assets().stream()
+                .map(this::assetLabel)
+                .toList();
+        String pattern = AssetPatternBuilder.build(assetName, candidateNames);
 
         pending.plan().getOptions().put("assetPattern", pattern);
         pendingSelections.remove(key);

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/AssetPatternBuilder.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/AssetPatternBuilder.java
@@ -1,5 +1,7 @@
 package eu.nurkert.neverUp2Late.fetcher;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -16,26 +18,102 @@ public final class AssetPatternBuilder {
     }
 
     public static String build(String assetName) {
+        return build(assetName, List.of());
+    }
+
+    public static String build(String assetName, List<String> otherAssets) {
         String value = Objects.requireNonNull(assetName, "assetName");
         value = value.trim();
         if (value.isEmpty()) {
             throw new IllegalArgumentException("assetName must not be blank");
         }
 
+        List<VersionToken> tokens = extractTokens(value);
+        boolean[] wildcard = new boolean[tokens.size()];
+        for (int i = 0; i < wildcard.length; i++) {
+            wildcard[i] = true;
+        }
+
+        String pattern = buildPattern(value, tokens, wildcard);
+
+        if (!conflicts(pattern, value, otherAssets)) {
+            return pattern;
+        }
+
+        for (int i = tokens.size() - 1; i >= 0; i--) {
+            if (!wildcard[i]) {
+                continue;
+            }
+            wildcard[i] = false;
+            pattern = buildPattern(value, tokens, wildcard);
+            if (!conflicts(pattern, value, otherAssets)) {
+                return pattern;
+            }
+        }
+
+        return pattern;
+    }
+
+    private static List<VersionToken> extractTokens(String value) {
         Matcher matcher = VERSION_TOKEN.matcher(value);
+        List<VersionToken> tokens = new ArrayList<>();
+        while (matcher.find()) {
+            tokens.add(new VersionToken(matcher.start(), matcher.end()));
+        }
+        return tokens;
+    }
+
+    private static String buildPattern(String value, List<VersionToken> tokens, boolean[] wildcard) {
         StringBuilder builder = new StringBuilder("(?i)^");
         int lastEnd = 0;
-        while (matcher.find()) {
-            if (matcher.start() > lastEnd) {
-                builder.append(Pattern.quote(value.substring(lastEnd, matcher.start())));
+        for (int i = 0; i < tokens.size(); i++) {
+            VersionToken token = tokens.get(i);
+            if (token.start() > lastEnd) {
+                builder.append(Pattern.quote(value.substring(lastEnd, token.start())));
             }
-            builder.append("\\d+(?:[._+-]\\d+)*");
-            lastEnd = matcher.end();
+            if (wildcard[i]) {
+                builder.append("\\d+(?:[._+-]\\d+)*");
+            } else {
+                builder.append(Pattern.quote(value.substring(token.start(), token.end())));
+            }
+            lastEnd = token.end();
         }
         if (lastEnd < value.length()) {
             builder.append(Pattern.quote(value.substring(lastEnd)));
         }
         builder.append('$');
         return builder.toString();
+    }
+
+    private static boolean conflicts(String pattern,
+                                     String selected,
+                                     List<String> otherAssets) {
+        if (otherAssets == null || otherAssets.isEmpty()) {
+            return false;
+        }
+
+        Pattern compiled = Pattern.compile(pattern);
+        String selectedNormalized = selected.trim();
+
+        for (String candidate : otherAssets) {
+            if (candidate == null) {
+                continue;
+            }
+            String normalized = candidate.trim();
+            if (normalized.isEmpty()) {
+                continue;
+            }
+            if (normalized.equalsIgnoreCase(selectedNormalized)) {
+                continue;
+            }
+            if (compiled.matcher(normalized).matches()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private record VersionToken(int start, int end) {
     }
 }

--- a/src/test/java/eu/nurkert/neverUp2Late/fetcher/AssetPatternBuilderTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/fetcher/AssetPatternBuilderTest.java
@@ -2,6 +2,7 @@ package eu.nurkert.neverUp2Late.fetcher;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,5 +30,16 @@ class AssetPatternBuilderTest {
     @Test
     void rejectsBlankInput() {
         assertThrows(IllegalArgumentException.class, () -> AssetPatternBuilder.build("   "));
+    }
+
+    @Test
+    void keepsSelectedVariantDistinctFromOtherAssets() {
+        String selected = "DynamicLights-1.3.0-FOR-MC1.20.jar";
+        String pattern = AssetPatternBuilder.build(selected,
+                List.of(selected, "DynamicLights-1.3.0-FOR-MC1.19.jar"));
+
+        Pattern compiled = Pattern.compile(pattern);
+        assertTrue(compiled.matcher("DynamicLights-1.4.0-FOR-MC1.20.jar").matches());
+        assertFalse(compiled.matcher("DynamicLights-1.4.0-FOR-MC1.19.jar").matches());
     }
 }


### PR DESCRIPTION
## Summary
- refine the GitHub asset regex builder so it only matches the user-selected variant when other assets share the same release
- pass all asset labels to the pattern builder during manual selection
- add a regression test that ensures variants for different Minecraft versions are no longer conflated

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68de6f114eb083229cfa31f60a6aa153