### PR TITLE
Disable automatic plugin lifecycle management by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Die Datei `plugins/NeverUp2Late/config.yml` enthält globale Einstellungen und d
 |--------------------------|----------------------------------------------------------------------------|
 | `filenames.<name>`       | Standarddateiname einer Quelle (z. B. `paper.jar`).                        |
 | `updateInterval`         | Prüfintervall in Minuten (Standard: 30).                                   |
+| `pluginLifecycle.autoManage` | Aktiviert automatisches Neu-/Entladen aktualisierter Plugins (Standard: aus). |
 | `ignoreUnstable`         | Legacy-Schalter, wird noch als Fallback für alte Konfigurationen gelesen. |
 | `updates.ignoreUnstable` | Globale Standardeinstellung für Fetcher, die instabile Builds filtern.    |
 
@@ -64,6 +65,8 @@ filenames:
   paper: "paper.jar"
 
 updateInterval: 30
+pluginLifecycle:
+  autoManage: false
 ignoreUnstable: true
 
 updates:
@@ -126,4 +129,4 @@ Sektion für fetcher-spezifische Einstellungen. Eigene Fetcher können über den
 NeverUp2Late prüft alle Quellen in dem eingestellten Intervall und nutzt dabei einen dreistufigen Pipeline-Job (Fetch → Download
 → Installation). Fehler werden geloggt; Netzwerkprobleme führen zu einer Warnung und wiederholten Versuchen. Manuell gestartete
 Läufe – etwa nach einer Schnellinstallation – melden Erfolg, Fehler und den Ablagepfad direkt im Chat. Nach erfolgreicher
-Installation sollte der Server neu gestartet werden, um neue JARs zu laden.
+Installation sollte der Server neu gestartet werden, um neue JARs zu laden. Das automatische Neu-/Entladen aktualisierter Plugins ist standardmäßig deaktiviert und kann bei Bedarf über `pluginLifecycle.autoManage` eingeschaltet werden.

--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -34,12 +34,18 @@ public final class NeverUp2Late extends JavaPlugin {
         }
 
         PersistentPluginHandler persistentPluginHandler = new PersistentPluginHandler(updateStateRepository);
-        PluginLifecycleManager pluginLifecycleManager = new PluginManagerApi(
-                getServer().getPluginManager(),
-                getDataFolder().getParentFile(),
-                getLogger()
-        );
-        pluginLifecycleManager.registerLoadedPlugins(this);
+        boolean lifecycleEnabled = configuration.getBoolean("pluginLifecycle.autoManage", false);
+        PluginLifecycleManager pluginLifecycleManager = null;
+        if (lifecycleEnabled) {
+            pluginLifecycleManager = new PluginManagerApi(
+                    getServer().getPluginManager(),
+                    getDataFolder().getParentFile(),
+                    getLogger()
+            );
+            pluginLifecycleManager.registerLoadedPlugins(this);
+        } else {
+            getLogger().fine("Plugin lifecycle management is disabled (pluginLifecycle.autoManage=false).");
+        }
 
         InstallationHandler installationHandler = new InstallationHandler(this, pluginLifecycleManager);
         UpdateSourceRegistry updateSourceRegistry = new UpdateSourceRegistry(getLogger(), configuration);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,6 +7,12 @@ filenames:
 # Check interval in minutes
 updateInterval: 30
 
+# Controls automatic plugin lifecycle operations (reload/unload).
+pluginLifecycle:
+  # When true, NeverUp2Late will attempt to reload updated plugins automatically.
+  # The default is false to avoid interfering with plugins that do not support reloads.
+  autoManage: false
+
 # Ignore unstable builds (legacy location, still respected if updates.ignoreUnstable is absent)
 ignoreUnstable: true
 


### PR DESCRIPTION
## Summary
- gate the plugin lifecycle manager behind a new `pluginLifecycle.autoManage` config flag that defaults to false
- document the new option in the README and update the sample configuration
- extend the default `config.yml` with comments explaining how to enable automatic reloads

## Testing
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68de72437c488322926c060eb0246684