### PR TITLE
Add plugin overview chest GUI

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -3,6 +3,7 @@ package eu.nurkert.neverUp2Late;
 import eu.nurkert.neverUp2Late.command.NeverUp2LateCommand;
 import eu.nurkert.neverUp2Late.command.QuickInstallCoordinator;
 import eu.nurkert.neverUp2Late.core.PluginContext;
+import eu.nurkert.neverUp2Late.gui.PluginOverviewGui;
 import eu.nurkert.neverUp2Late.handlers.ArtifactDownloader;
 import eu.nurkert.neverUp2Late.handlers.InstallationHandler;
 import eu.nurkert.neverUp2Late.handlers.PersistentPluginHandler;
@@ -72,7 +73,8 @@ public final class NeverUp2Late extends JavaPlugin {
         getServer().getPluginManager().registerEvents(installationHandler, this);
 
         QuickInstallCoordinator coordinator = new QuickInstallCoordinator(context);
-        NeverUp2LateCommand command = new NeverUp2LateCommand(coordinator);
+        PluginOverviewGui overviewGui = new PluginOverviewGui(context);
+        NeverUp2LateCommand command = new NeverUp2LateCommand(coordinator, overviewGui);
         PluginCommand pluginCommand = getCommand("nu2l");
         if (pluginCommand != null) {
             pluginCommand.setExecutor(command);

--- a/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
@@ -1,10 +1,12 @@
 package eu.nurkert.neverUp2Late.command;
 
+import eu.nurkert.neverUp2Late.gui.PluginOverviewGui;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
 
 import java.util.Collections;
 import java.util.List;
@@ -13,9 +15,11 @@ import java.util.Objects;
 public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
 
     private final QuickInstallCoordinator coordinator;
+    private final PluginOverviewGui overviewGui;
 
-    public NeverUp2LateCommand(QuickInstallCoordinator coordinator) {
+    public NeverUp2LateCommand(QuickInstallCoordinator coordinator, PluginOverviewGui overviewGui) {
         this.coordinator = Objects.requireNonNull(coordinator, "coordinator");
+        this.overviewGui = Objects.requireNonNull(overviewGui, "overviewGui");
     }
 
     @Override
@@ -25,17 +29,21 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
+        if (args.length == 0 || "gui".equalsIgnoreCase(args[0])) {
+            if (sender instanceof Player player) {
+                overviewGui.open(player);
+            } else {
+                sender.sendMessage(ChatColor.RED + "Die grafische Oberfläche kann nur von Spielern geöffnet werden.");
+            }
+            return true;
+        }
+
         if (args.length > 0 && "select".equalsIgnoreCase(args[0])) {
             if (args.length < 2) {
                 sender.sendMessage(ChatColor.RED + "Bitte gib die Nummer der gewünschten Datei an.");
                 return true;
             }
             coordinator.handleAssetSelection(sender, args[1]);
-            return true;
-        }
-
-        if (args.length == 0) {
-            sender.sendMessage(ChatColor.RED + "Verwendung: /" + label + " <url> oder /" + label + " select <nummer>");
             return true;
         }
 
@@ -51,6 +59,12 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
 
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            return List.of("gui", "select");
+        }
+        if (args.length == 2 && "select".equalsIgnoreCase(args[0])) {
+            return Collections.singletonList("<nummer>");
+        }
         return Collections.emptyList();
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
@@ -1,0 +1,109 @@
+package eu.nurkert.neverUp2Late.gui;
+
+import eu.nurkert.neverUp2Late.core.PluginContext;
+import eu.nurkert.neverUp2Late.plugin.ManagedPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Creates a simple chest based GUI that lists all plugins currently managed by NU2L.
+ */
+public class PluginOverviewGui {
+
+    private static final int MAX_SIZE = 54;
+
+    private final PluginContext context;
+
+    public PluginOverviewGui(PluginContext context) {
+        this.context = Objects.requireNonNull(context, "context");
+    }
+
+    public void open(Player player) {
+        List<ManagedPlugin> plugins = context.getPluginLifecycleManager().getManagedPlugins()
+                .stream()
+                .sorted(Comparator.comparing(ManagedPlugin::getName, String.CASE_INSENSITIVE_ORDER))
+                .toList();
+
+        int size = Math.max(9, ((plugins.size() + 8) / 9) * 9);
+        size = Math.min(size, MAX_SIZE);
+
+        Inventory inventory = Bukkit.createInventory(null, size, ChatColor.DARK_PURPLE + "NU2L Plugins");
+
+        ItemStack filler = createFiller();
+        for (int i = 0; i < size; i++) {
+            inventory.setItem(i, filler.clone());
+        }
+
+        boolean truncated = plugins.size() > size;
+        for (int slot = 0; slot < size && slot < plugins.size(); slot++) {
+            ManagedPlugin plugin = plugins.get(slot);
+            inventory.setItem(slot, createPluginItem(plugin));
+        }
+
+        player.openInventory(inventory);
+
+        if (truncated) {
+            player.sendMessage(ChatColor.YELLOW + "Es werden nur die ersten " + size
+                    + " Plugins angezeigt (" + plugins.size() + " insgesamt).");
+        }
+    }
+
+    private ItemStack createPluginItem(ManagedPlugin plugin) {
+        ItemStack item = new ItemStack(Material.ENCHANTED_BOOK);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.GOLD + plugin.getName());
+
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GRAY + "Status: " + statusLabel(plugin));
+            plugin.getPlugin().ifPresentOrElse(loaded -> {
+                String version = loaded.getDescription().getVersion();
+                if (version != null && !version.isBlank()) {
+                    lore.add(ChatColor.GRAY + "Version: " + ChatColor.AQUA + version);
+                }
+                lore.add(ChatColor.GRAY + "Aktiviert: "
+                        + (loaded.isEnabled() ? ChatColor.GREEN + "Ja" : ChatColor.RED + "Nein"));
+            }, () -> lore.add(ChatColor.RED + "Nicht geladen"));
+
+            Path path = plugin.getPath();
+            if (path != null) {
+                lore.add(ChatColor.DARK_GRAY + "Datei: " + ChatColor.WHITE + path.getFileName());
+            }
+
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private String statusLabel(ManagedPlugin plugin) {
+        if (plugin.isEnabled()) {
+            return ChatColor.GREEN + "Aktiv";
+        }
+        if (plugin.isLoaded()) {
+            return ChatColor.YELLOW + "Geladen";
+        }
+        return ChatColor.RED + "Nicht geladen";
+    }
+
+    private ItemStack createFiller() {
+        ItemStack item = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+}


### PR DESCRIPTION
## Summary
- add a chest-style PluginOverviewGui that visualises the managed plugins
- wire the /nu2l command to open the overview GUI for players and suggest new subcommands
- bootstrap the GUI from the plugin entry point for future configuration screens

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68de72b212ec83229995ae9c977cef99