### PR TITLE
Add GUI flow to link installed plugins with update sources

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -79,7 +79,7 @@ public final class NeverUp2Late extends JavaPlugin {
         getServer().getPluginManager().registerEvents(installationHandler, this);
 
         QuickInstallCoordinator coordinator = new QuickInstallCoordinator(context);
-        PluginOverviewGui overviewGui = new PluginOverviewGui(context);
+        PluginOverviewGui overviewGui = new PluginOverviewGui(context, coordinator);
         NeverUp2LateCommand command = new NeverUp2LateCommand(coordinator, overviewGui);
         PluginCommand pluginCommand = getCommand("nu2l");
         if (pluginCommand != null) {
@@ -88,6 +88,8 @@ public final class NeverUp2Late extends JavaPlugin {
         } else {
             getLogger().warning("Failed to register /nu2l command; entry missing in plugin.yml");
         }
+
+        getServer().getPluginManager().registerEvents(overviewGui, this);
     }
 
     @Override

--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -59,6 +59,14 @@ public class QuickInstallCoordinator {
     }
 
     public void install(CommandSender sender, String rawUrl) {
+        install(sender, rawUrl, null);
+    }
+
+    public void installForPlugin(CommandSender sender, String pluginName, String rawUrl) {
+        install(sender, rawUrl, pluginName);
+    }
+
+    private void install(CommandSender sender, String rawUrl, String forcedPluginName) {
         String url = rawUrl != null ? rawUrl.trim() : "";
         if (url.isEmpty()) {
             send(sender, ChatColor.RED + "Bitte gib eine gültige URL an.");
@@ -84,10 +92,15 @@ public class QuickInstallCoordinator {
         }
 
         plan.setSourceName(ensureUniqueName(plan.getSuggestedName()));
-        detectInstalledPlugin(plan).ifPresent(installed -> {
-            plan.setInstalledPluginName(installed);
-            send(sender, ChatColor.GRAY + "Verknüpfe mit installiertem Plugin: " + installed);
-        });
+        if (forcedPluginName != null && !forcedPluginName.isBlank()) {
+            plan.setInstalledPluginName(forcedPluginName);
+            send(sender, ChatColor.GRAY + "Verknüpfe mit ausgewähltem Plugin: " + forcedPluginName);
+        } else {
+            detectInstalledPlugin(plan).ifPresent(installed -> {
+                plan.setInstalledPluginName(installed);
+                send(sender, ChatColor.GRAY + "Verknüpfe mit installiertem Plugin: " + installed);
+            });
+        }
 
         send(sender, ChatColor.AQUA + "Quelle erkannt: " + plan.getDisplayName() + " (" + plan.getProvider() + ")");
 

--- a/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
@@ -1,11 +1,20 @@
 package eu.nurkert.neverUp2Late.gui;
 
+import eu.nurkert.neverUp2Late.command.QuickInstallCoordinator;
 import eu.nurkert.neverUp2Late.core.PluginContext;
 import eu.nurkert.neverUp2Late.plugin.ManagedPlugin;
+import eu.nurkert.neverUp2Late.update.UpdateSourceRegistry.TargetDirectory;
+import eu.nurkert.neverUp2Late.update.UpdateSourceRegistry.UpdateSource;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -13,20 +22,29 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Creates a simple chest based GUI that lists all plugins currently managed by NU2L.
  */
-public class PluginOverviewGui {
+public class PluginOverviewGui implements Listener {
 
     private static final int MAX_SIZE = 54;
 
     private final PluginContext context;
+    private final QuickInstallCoordinator coordinator;
+    private final Map<UUID, InventorySession> openInventories = new ConcurrentHashMap<>();
+    private final Map<UUID, LinkRequest> pendingLinkRequests = new ConcurrentHashMap<>();
 
-    public PluginOverviewGui(PluginContext context) {
+    public PluginOverviewGui(PluginContext context, QuickInstallCoordinator coordinator) {
         this.context = Objects.requireNonNull(context, "context");
+        this.coordinator = Objects.requireNonNull(coordinator, "coordinator");
     }
 
     public void open(Player player) {
@@ -45,12 +63,15 @@ public class PluginOverviewGui {
             inventory.setItem(i, filler.clone());
         }
 
+        Map<Integer, ManagedPlugin> slotMapping = new HashMap<>();
         boolean truncated = plugins.size() > size;
         for (int slot = 0; slot < size && slot < plugins.size(); slot++) {
             ManagedPlugin plugin = plugins.get(slot);
             inventory.setItem(slot, createPluginItem(plugin));
+            slotMapping.put(slot, plugin);
         }
 
+        openInventories.put(player.getUniqueId(), new InventorySession(inventory, Map.copyOf(slotMapping)));
         player.openInventory(inventory);
 
         if (truncated) {
@@ -79,6 +100,12 @@ public class PluginOverviewGui {
             Path path = plugin.getPath();
             if (path != null) {
                 lore.add(ChatColor.DARK_GRAY + "Datei: " + ChatColor.WHITE + path.getFileName());
+                findMatchingSource(plugin).ifPresentOrElse(source -> {
+                    lore.add(ChatColor.GRAY + "Update-Quelle: " + ChatColor.AQUA + source.getName());
+                    lore.add(ChatColor.YELLOW + "Klicke, um den Link zu aktualisieren.");
+                }, () -> lore.add(ChatColor.RED + "Keine Update-Quelle verknüpft – klicken, um Link zu setzen."));
+            } else {
+                lore.add(ChatColor.RED + "Kein JAR-Pfad gefunden – Link nicht möglich.");
             }
 
             meta.setLore(lore);
@@ -105,5 +132,122 @@ public class PluginOverviewGui {
             item.setItemMeta(meta);
         }
         return item;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        InventorySession session = openInventories.get(player.getUniqueId());
+        if (session == null) {
+            return;
+        }
+
+        if (!event.getView().getTopInventory().equals(session.inventory())) {
+            return;
+        }
+
+        if (event.getRawSlot() >= session.inventory().getSize()) {
+            event.setCancelled(true);
+            return;
+        }
+
+        event.setCancelled(true);
+        ManagedPlugin plugin = session.plugins().get(event.getRawSlot());
+        if (plugin == null) {
+            return;
+        }
+
+        beginLinking(player, plugin);
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        openInventories.remove(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        UUID playerId = event.getPlayer().getUniqueId();
+        openInventories.remove(playerId);
+        pendingLinkRequests.remove(playerId);
+    }
+
+    @EventHandler
+    public void onPlayerChat(AsyncPlayerChatEvent event) {
+        Player player = event.getPlayer();
+        UUID playerId = player.getUniqueId();
+        LinkRequest request = pendingLinkRequests.get(playerId);
+        if (request == null) {
+            return;
+        }
+
+        event.setCancelled(true);
+        String message = event.getMessage() != null ? event.getMessage().trim() : "";
+        context.getScheduler().runTask(context.getPlugin(),
+                () -> handleChatInput(player, message, request));
+    }
+
+    private void handleChatInput(Player player, String message, LinkRequest request) {
+        UUID playerId = player.getUniqueId();
+        if (pendingLinkRequests.get(playerId) != request) {
+            return;
+        }
+
+        if (message.isBlank()) {
+            player.sendMessage(ChatColor.RED + "Bitte gib einen gültigen Link ein oder tippe 'abbrechen'.");
+            return;
+        }
+
+        if (message.equalsIgnoreCase("abbrechen") || message.equalsIgnoreCase("cancel")) {
+            pendingLinkRequests.remove(playerId);
+            player.sendMessage(ChatColor.YELLOW + "Verknüpfung abgebrochen.");
+            return;
+        }
+
+        pendingLinkRequests.remove(playerId);
+        player.sendMessage(ChatColor.GREEN + "Verarbeite Link für " + ChatColor.AQUA + request.pluginName() + ChatColor.GREEN + " …");
+        coordinator.installForPlugin(player, request.pluginName(), message);
+    }
+
+    private void beginLinking(Player player, ManagedPlugin plugin) {
+        player.closeInventory();
+        openInventories.remove(player.getUniqueId());
+
+        Path path = plugin.getPath();
+        if (path == null) {
+            player.sendMessage(ChatColor.RED + "Für dieses Plugin konnte kein JAR gefunden werden.");
+            return;
+        }
+
+        String pluginName = plugin.getName();
+        pendingLinkRequests.put(player.getUniqueId(), new LinkRequest(pluginName));
+
+        player.sendMessage(ChatColor.AQUA + "Update-Link für " + pluginName + " festlegen.");
+        findMatchingSource(plugin).ifPresentOrElse(source ->
+                        player.sendMessage(ChatColor.GRAY + "Aktuelle Quelle: " + ChatColor.AQUA + source.getName()),
+                () -> player.sendMessage(ChatColor.GRAY + "Aktuell ist keine Quelle verknüpft."));
+        player.sendMessage(ChatColor.YELLOW + "Bitte gib die Download-URL im Chat ein oder tippe 'abbrechen'.");
+    }
+
+    private Optional<UpdateSource> findMatchingSource(ManagedPlugin plugin) {
+        Path path = plugin.getPath();
+        if (path == null) {
+            return Optional.empty();
+        }
+
+        String fileName = path.getFileName().toString();
+        return context.getUpdateSourceRegistry().getSources().stream()
+                .filter(source -> source.getTargetDirectory() == TargetDirectory.PLUGINS)
+                .filter(source -> fileName.equalsIgnoreCase(source.getFilename()))
+                .findFirst();
+    }
+
+    private record InventorySession(Inventory inventory, Map<Integer, ManagedPlugin> plugins) {
+    }
+
+    private record LinkRequest(String pluginName) {
     }
 }


### PR DESCRIPTION
## Summary
- allow forcing a QuickInstall installation to attach to a selected plugin
- extend the plugin overview GUI so players can click entries, provide URLs, and see linked update sources
- register the GUI as a listener during plugin startup

## Testing
- `mvn -q -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68de744ed9bc8322865e1126f72e2877