### PR TITLE
Add plugin management GUI and update preference storage

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -17,6 +17,7 @@ import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import eu.nurkert.neverUp2Late.persistence.LegacyConfigMigrator;
+import eu.nurkert.neverUp2Late.persistence.PluginUpdateSettingsRepository;
 import eu.nurkert.neverUp2Late.persistence.UpdateStateRepository;
 
 public final class NeverUp2Late extends JavaPlugin {
@@ -35,6 +36,7 @@ public final class NeverUp2Late extends JavaPlugin {
         }
 
         PersistentPluginHandler persistentPluginHandler = new PersistentPluginHandler(updateStateRepository);
+        PluginUpdateSettingsRepository updateSettingsRepository = PluginUpdateSettingsRepository.forPlugin(this);
         boolean lifecycleEnabled = configuration.getBoolean("pluginLifecycle.autoManage", false);
         PluginLifecycleManager pluginLifecycleManager = null;
         if (lifecycleEnabled) {
@@ -48,7 +50,7 @@ public final class NeverUp2Late extends JavaPlugin {
             getLogger().fine("Plugin lifecycle management is disabled (pluginLifecycle.autoManage=false).");
         }
 
-        InstallationHandler installationHandler = new InstallationHandler(this, pluginLifecycleManager);
+        InstallationHandler installationHandler = new InstallationHandler(this, pluginLifecycleManager, updateSettingsRepository);
         UpdateSourceRegistry updateSourceRegistry = new UpdateSourceRegistry(getLogger(), configuration);
         ArtifactDownloader artifactDownloader = new ArtifactDownloader();
         VersionComparator versionComparator = new VersionComparator();
@@ -61,7 +63,9 @@ public final class NeverUp2Late extends JavaPlugin {
                 installationHandler,
                 updateSourceRegistry,
                 artifactDownloader,
-                versionComparator
+                versionComparator,
+                pluginLifecycleManager,
+                updateSettingsRepository
         );
 
         context = new PluginContext(
@@ -72,7 +76,8 @@ public final class NeverUp2Late extends JavaPlugin {
                 updateHandler,
                 installationHandler,
                 updateSourceRegistry,
-                pluginLifecycleManager
+                pluginLifecycleManager,
+                updateSettingsRepository
         );
 
         updateHandler.start();

--- a/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
@@ -4,6 +4,7 @@ import eu.nurkert.neverUp2Late.handlers.InstallationHandler;
 import eu.nurkert.neverUp2Late.handlers.PersistentPluginHandler;
 import eu.nurkert.neverUp2Late.handlers.UpdateHandler;
 import eu.nurkert.neverUp2Late.plugin.PluginLifecycleManager;
+import eu.nurkert.neverUp2Late.persistence.PluginUpdateSettingsRepository;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -22,6 +23,7 @@ public class PluginContext {
     private final InstallationHandler installationHandler;
     private final eu.nurkert.neverUp2Late.update.UpdateSourceRegistry updateSourceRegistry;
     private final PluginLifecycleManager pluginLifecycleManager;
+    private final PluginUpdateSettingsRepository pluginUpdateSettingsRepository;
 
     public PluginContext(JavaPlugin plugin,
                          BukkitScheduler scheduler,
@@ -30,7 +32,8 @@ public class PluginContext {
                          UpdateHandler updateHandler,
                          InstallationHandler installationHandler,
                          eu.nurkert.neverUp2Late.update.UpdateSourceRegistry updateSourceRegistry,
-                         PluginLifecycleManager pluginLifecycleManager) {
+                         PluginLifecycleManager pluginLifecycleManager,
+                         PluginUpdateSettingsRepository pluginUpdateSettingsRepository) {
         this.plugin = plugin;
         this.scheduler = scheduler;
         this.configuration = configuration;
@@ -39,6 +42,7 @@ public class PluginContext {
         this.installationHandler = installationHandler;
         this.updateSourceRegistry = updateSourceRegistry;
         this.pluginLifecycleManager = pluginLifecycleManager;
+        this.pluginUpdateSettingsRepository = pluginUpdateSettingsRepository;
     }
 
     public JavaPlugin getPlugin() {
@@ -71,5 +75,9 @@ public class PluginContext {
 
     public PluginLifecycleManager getPluginLifecycleManager() {
         return pluginLifecycleManager;
+    }
+
+    public PluginUpdateSettingsRepository getPluginUpdateSettingsRepository() {
+        return pluginUpdateSettingsRepository;
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/persistence/PluginUpdateSettingsRepository.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/persistence/PluginUpdateSettingsRepository.java
@@ -1,0 +1,165 @@
+package eu.nurkert.neverUp2Late.persistence;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Persists per-plugin update preferences such as the preferred post-update
+ * behaviour and whether automatic update checks should be executed.
+ */
+public class PluginUpdateSettingsRepository {
+
+    private static final String FILE_NAME = "plugin-settings.yml";
+    private static final String ROOT_NODE = "plugins";
+    private static final String AUTO_UPDATE_NODE = "autoUpdate";
+    private static final String BEHAVIOUR_NODE = "behaviour";
+
+    private final File dataFolder;
+    private final Logger logger;
+    private final File stateFile;
+
+    private FileConfiguration configuration;
+
+    public PluginUpdateSettingsRepository(File dataFolder, Logger logger) {
+        this.dataFolder = Objects.requireNonNull(dataFolder, "dataFolder");
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.stateFile = new File(dataFolder, FILE_NAME);
+        initialise();
+    }
+
+    public static PluginUpdateSettingsRepository forPlugin(JavaPlugin plugin) {
+        return new PluginUpdateSettingsRepository(plugin.getDataFolder(), plugin.getLogger());
+    }
+
+    private void initialise() {
+        ensureDataFolderExists();
+        ensureStateFileExists();
+        configuration = YamlConfiguration.loadConfiguration(stateFile);
+        if (configuration.getConfigurationSection(ROOT_NODE) == null) {
+            configuration.createSection(ROOT_NODE);
+            saveInternal();
+        }
+    }
+
+    private void ensureDataFolderExists() {
+        if (!dataFolder.exists() && !dataFolder.mkdirs()) {
+            logger.log(Level.WARNING, "Could not create plugin data folder at {0}", dataFolder.getAbsolutePath());
+        }
+    }
+
+    private void ensureStateFileExists() {
+        if (!stateFile.exists()) {
+            try {
+                if (!stateFile.createNewFile()) {
+                    logger.log(Level.WARNING, "Unable to create {0}", stateFile.getAbsolutePath());
+                }
+            } catch (IOException e) {
+                logger.log(Level.SEVERE, "Failed to create " + FILE_NAME, e);
+            }
+        }
+    }
+
+    public synchronized PluginUpdateSettings getSettings(String pluginName) {
+        if (pluginName == null || pluginName.isBlank()) {
+            return PluginUpdateSettings.defaultSettings();
+        }
+
+        ConfigurationSection section = configuration.getConfigurationSection(pathForPlugin(pluginName));
+        if (section == null) {
+            return PluginUpdateSettings.defaultSettings();
+        }
+
+        boolean autoUpdate = section.getBoolean(AUTO_UPDATE_NODE, true);
+        String behaviourValue = section.getString(BEHAVIOUR_NODE);
+        UpdateBehaviour behaviour = UpdateBehaviour.parse(behaviourValue)
+                .orElse(UpdateBehaviour.REQUIRE_RESTART);
+        return new PluginUpdateSettings(autoUpdate, behaviour);
+    }
+
+    public synchronized void saveSettings(String pluginName, PluginUpdateSettings settings) {
+        if (pluginName == null || pluginName.isBlank() || settings == null) {
+            return;
+        }
+
+        ConfigurationSection section = configuration.getConfigurationSection(pathForPlugin(pluginName));
+        if (section == null) {
+            section = configuration.createSection(pathForPlugin(pluginName));
+        }
+
+        section.set(AUTO_UPDATE_NODE, settings.autoUpdateEnabled());
+        section.set(BEHAVIOUR_NODE, settings.behaviour().name());
+        saveInternal();
+    }
+
+    public synchronized Map<String, PluginUpdateSettings> getAllSettings() {
+        ConfigurationSection root = configuration.getConfigurationSection(ROOT_NODE);
+        if (root == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, PluginUpdateSettings> settings = new HashMap<>();
+        for (String key : root.getKeys(false)) {
+            settings.put(key, getSettings(key));
+        }
+        return settings;
+    }
+
+    private String pathForPlugin(String pluginName) {
+        return ROOT_NODE + "." + pluginName;
+    }
+
+    private void saveInternal() {
+        try {
+            configuration.save(stateFile);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to save plugin update settings", e);
+        }
+    }
+
+    public enum UpdateBehaviour {
+        AUTO_RELOAD,
+        REQUIRE_RESTART;
+
+        private static final Map<String, UpdateBehaviour> LOOKUP;
+
+        static {
+            Map<String, UpdateBehaviour> map = new HashMap<>();
+            for (UpdateBehaviour behaviour : values()) {
+                map.put(behaviour.name(), behaviour);
+            }
+            LOOKUP = Collections.unmodifiableMap(map);
+        }
+
+        public static java.util.Optional<UpdateBehaviour> parse(String value) {
+            if (value == null || value.isBlank()) {
+                return java.util.Optional.empty();
+            }
+            return java.util.Optional.ofNullable(LOOKUP.get(value.trim().toUpperCase()))
+                    .or(() -> java.util.Optional.ofNullable(LOOKUP.get(value.trim())));
+        }
+    }
+
+    public record PluginUpdateSettings(boolean autoUpdateEnabled, UpdateBehaviour behaviour) {
+        public PluginUpdateSettings {
+            if (behaviour == null) {
+                behaviour = UpdateBehaviour.REQUIRE_RESTART;
+            }
+        }
+
+        public static PluginUpdateSettings defaultSettings() {
+            return new PluginUpdateSettings(true, UpdateBehaviour.REQUIRE_RESTART);
+        }
+    }
+}
+

--- a/src/test/java/eu/nurkert/neverUp2Late/handlers/InstallationHandlerTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/handlers/InstallationHandlerTest.java
@@ -91,7 +91,7 @@ class InstallationHandlerTest {
         StubLifecycleManager lifecycleManager = new StubLifecycleManager();
         lifecycleManager.reloadResult = true;
 
-        InstallationHandler handler = new InstallationHandler(server, repository, logger, lifecycleManager);
+        InstallationHandler handler = new InstallationHandler(server, repository, logger, lifecycleManager, null);
         UpdateCompletedEvent event = createEvent();
 
         handler.onUpdateCompleted(event);
@@ -112,7 +112,7 @@ class InstallationHandlerTest {
         StubLifecycleManager lifecycleManager = new StubLifecycleManager();
         lifecycleManager.reloadResult = false;
 
-        InstallationHandler handler = new InstallationHandler(server, repository, logger, lifecycleManager);
+        InstallationHandler handler = new InstallationHandler(server, repository, logger, lifecycleManager, null);
 
         handler.onUpdateCompleted(createEvent());
 
@@ -147,7 +147,7 @@ class InstallationHandlerTest {
     }
 
     private UpdateCompletedEvent createEvent() {
-        UpdateSource source = new UpdateSource("test", null, TargetDirectory.PLUGINS, "test.jar");
+        UpdateSource source = new UpdateSource("test", null, TargetDirectory.PLUGINS, "test.jar", null);
         return new UpdateCompletedEvent(source, Path.of("plugins/test.jar"), "1.0", 1, Path.of("plugins/test.jar"), "");
     }
 


### PR DESCRIPTION
## Summary
- Persist per-plugin update preferences through a new PluginUpdateSettingsRepository and surface it via PluginContext and NeverUp2Late wiring.
- Expand the chest GUI to include plugin detail controls for load/unload, enable/disable, update behaviour cycling, and a chat-driven flow to install new plugins.
- Honour stored preferences during automatic updates by skipping disabled plugins, preferring reloads where configured, and propagating plugin names through UpdateSourceRegistry.

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68de78f626548322b66a53e0497e8d68