### PR TITLE
Open settings GUI when lifecycle management is disabled

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
@@ -68,6 +68,8 @@ public class PluginOverviewGui implements Listener {
     public void open(Player player) {
         if (!context.isPluginLifecycleEnabled()) {
             player.sendMessage(ChatColor.YELLOW + "Die Plugin-Verwaltung ist deaktiviert. Aktiviere sie in den Einstellungen.");
+            settingsGui.open(player);
+            return;
         }
         openOverview(player);
     }


### PR DESCRIPTION
## Summary
- automatically redirect players to the settings interface when plugin lifecycle management is disabled so they can enable it from there

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68de8584b1848322a6735abd967f85da