### PR TITLE
Migrate legacy config entries into dedicated persistence files

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -30,13 +30,13 @@ public final class NeverUp2Late extends JavaPlugin {
         FileConfiguration configuration = getConfig();
 
         UpdateStateRepository updateStateRepository = UpdateStateRepository.forPlugin(this);
-        LegacyConfigMigrator migrator = new LegacyConfigMigrator(configuration, updateStateRepository, getLogger());
+        PluginUpdateSettingsRepository updateSettingsRepository = PluginUpdateSettingsRepository.forPlugin(this);
+        LegacyConfigMigrator migrator = new LegacyConfigMigrator(configuration, updateStateRepository, updateSettingsRepository, getLogger());
         if (migrator.migrate()) {
             saveConfig();
         }
 
         PersistentPluginHandler persistentPluginHandler = new PersistentPluginHandler(updateStateRepository);
-        PluginUpdateSettingsRepository updateSettingsRepository = PluginUpdateSettingsRepository.forPlugin(this);
         boolean lifecycleEnabled = configuration.getBoolean("pluginLifecycle.autoManage", false);
         PluginLifecycleManager pluginLifecycleManager = null;
         if (lifecycleEnabled) {

--- a/src/main/java/eu/nurkert/neverUp2Late/persistence/LegacyConfigMigrator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/persistence/LegacyConfigMigrator.java
@@ -1,5 +1,8 @@
 package eu.nurkert.neverUp2Late.persistence;
 
+import eu.nurkert.neverUp2Late.persistence.PluginUpdateSettingsRepository;
+import eu.nurkert.neverUp2Late.persistence.PluginUpdateSettingsRepository.PluginUpdateSettings;
+import eu.nurkert.neverUp2Late.persistence.PluginUpdateSettingsRepository.UpdateBehaviour;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
@@ -10,23 +13,30 @@ import java.util.logging.Logger;
 
 /**
  * Migrates legacy plugin state stored in {@code config.yml} into the dedicated
- * {@code plugins.yml} persistence file.
+ * {@code plugins.yml} persistence file and transfers per-plugin settings into
+ * {@code plugin-settings.yml}.
  */
 public class LegacyConfigMigrator {
 
     private static final String PLUGINS_NODE = "plugins";
     private static final String BUILD_NODE = "build";
     private static final String VERSION_NODE = "version";
+    private static final String AUTO_UPDATE_NODE = "autoUpdate";
+    private static final String BEHAVIOUR_NODE = "behaviour";
+    private static final String RETENTION_NODE = "retainUpstreamFilename";
 
     private final FileConfiguration configuration;
     private final UpdateStateRepository repository;
+    private final PluginUpdateSettingsRepository settingsRepository;
     private final Logger logger;
 
     public LegacyConfigMigrator(FileConfiguration configuration,
                                 UpdateStateRepository repository,
+                                PluginUpdateSettingsRepository settingsRepository,
                                 Logger logger) {
         this.configuration = configuration;
         this.repository = repository;
+        this.settingsRepository = settingsRepository;
         this.logger = logger;
     }
 
@@ -54,9 +64,23 @@ public class LegacyConfigMigrator {
         for (String pluginKey : pluginKeys) {
             mutated = true;
 
-            LegacyPluginState state = readState(pluginsSection, pluginKey);
-            if (state != null) {
-                repository.savePluginState(pluginKey, state.build(), state.version());
+            LegacyPluginData data = readData(pluginsSection, pluginKey);
+            boolean migratedEntry = false;
+            if (data != null) {
+                LegacyPluginState state = data.state();
+                if (state != null) {
+                    repository.savePluginState(pluginKey, state.build(), state.version());
+                    migratedEntry = true;
+                }
+
+                PluginUpdateSettings settings = data.settings();
+                if (settings != null) {
+                    settingsRepository.saveSettings(pluginKey, settings);
+                    migratedEntry = true;
+                }
+            }
+
+            if (migratedEntry) {
                 migratedPlugins++;
             }
 
@@ -69,41 +93,70 @@ public class LegacyConfigMigrator {
         }
 
         if (migratedPlugins > 0) {
-            logger.log(Level.INFO, "Migrated {0} legacy plugin entr{1} from config.yml to plugins.yml.",
+            logger.log(Level.INFO,
+                    "Migrated {0} legacy plugin entr{1} from config.yml to dedicated persistence files.",
                     new Object[]{migratedPlugins, migratedPlugins == 1 ? "y" : "ies"});
         }
 
         return mutated;
     }
 
-    private LegacyPluginState readState(ConfigurationSection pluginsSection, String pluginKey) {
+    private LegacyPluginData readData(ConfigurationSection pluginsSection, String pluginKey) {
         ConfigurationSection pluginSection = pluginsSection.getConfigurationSection(pluginKey);
+
+        LegacyPluginState state = null;
+        PluginUpdateSettings settings = null;
+
+        if (pluginSection != null) {
+            state = readStateFromSection(pluginSection, pluginKey);
+            settings = readSettings(pluginSection, pluginKey);
+        } else {
+            state = readStateFromValue(pluginsSection.get(pluginKey), pluginKey);
+        }
+
+        if (state == null && settings == null) {
+            return null;
+        }
+
+        return new LegacyPluginData(state, settings);
+    }
+
+    private LegacyPluginState readStateFromSection(ConfigurationSection pluginSection, String pluginKey) {
         Integer build = null;
         String version = null;
 
-        if (pluginSection != null) {
-            if (pluginSection.contains(BUILD_NODE)) {
-                Object buildValue = pluginSection.get(BUILD_NODE);
-                build = toInteger(buildValue, pluginKey);
-            }
-            if (pluginSection.contains(VERSION_NODE)) {
-                Object versionValue = pluginSection.get(VERSION_NODE);
-                if (versionValue != null) {
-                    version = versionValue.toString();
-                }
-            }
-        } else {
-            Object value = pluginsSection.get(pluginKey);
-            if (value instanceof Number number) {
-                build = number.intValue();
-            } else if (value instanceof String string) {
-                version = string;
-            } else if (value != null) {
-                logger.log(Level.WARNING,
-                        "Ignoring unsupported legacy entry {0} in config.yml during migration.", pluginKey);
+        if (pluginSection.contains(BUILD_NODE)) {
+            Object buildValue = pluginSection.get(BUILD_NODE);
+            build = toInteger(buildValue, pluginKey);
+        }
+
+        if (pluginSection.contains(VERSION_NODE)) {
+            Object versionValue = pluginSection.get(VERSION_NODE);
+            if (versionValue != null) {
+                version = versionValue.toString();
             }
         }
 
+        return normaliseState(build, version);
+    }
+
+    private LegacyPluginState readStateFromValue(Object value, String pluginKey) {
+        Integer build = null;
+        String version = null;
+
+        if (value instanceof Number number) {
+            build = number.intValue();
+        } else if (value instanceof String string) {
+            version = string;
+        } else if (value != null) {
+            logger.log(Level.WARNING,
+                    "Ignoring unsupported legacy entry {0} in config.yml during migration.", pluginKey);
+        }
+
+        return normaliseState(build, version);
+    }
+
+    private LegacyPluginState normaliseState(Integer build, String version) {
         if (build == null && (version == null || version.isBlank())) {
             return null;
         }
@@ -113,6 +166,59 @@ public class LegacyConfigMigrator {
         }
 
         return new LegacyPluginState(build, version);
+    }
+
+    private PluginUpdateSettings readSettings(ConfigurationSection pluginSection, String pluginKey) {
+        Boolean autoUpdate = null;
+        UpdateBehaviour behaviour = null;
+        Boolean retainFilename = null;
+
+        if (pluginSection.contains(AUTO_UPDATE_NODE)) {
+            Object value = pluginSection.get(AUTO_UPDATE_NODE);
+            autoUpdate = toBoolean(value, pluginKey, AUTO_UPDATE_NODE);
+        }
+
+        if (pluginSection.contains(BEHAVIOUR_NODE)) {
+            String behaviourValue = pluginSection.getString(BEHAVIOUR_NODE);
+            if (behaviourValue != null && !behaviourValue.isBlank()) {
+                behaviour = UpdateBehaviour.parse(behaviourValue)
+                        .orElseGet(() -> {
+                            logger.log(Level.WARNING,
+                                    "Ignoring unknown behaviour '{0}' for legacy plugin entry {1}",
+                                    new Object[]{behaviourValue, pluginKey});
+                            return null;
+                        });
+            }
+        }
+
+        if (pluginSection.contains(RETENTION_NODE)) {
+            Object value = pluginSection.get(RETENTION_NODE);
+            retainFilename = toBoolean(value, pluginKey, RETENTION_NODE);
+        }
+
+        if (autoUpdate == null && behaviour == null && retainFilename == null) {
+            return null;
+        }
+
+        PluginUpdateSettings settings = PluginUpdateSettings.defaultSettings();
+        boolean mutated = false;
+
+        if (autoUpdate != null) {
+            settings = new PluginUpdateSettings(autoUpdate, settings.behaviour(), settings.retainUpstreamFilename());
+            mutated = true;
+        }
+
+        if (behaviour != null) {
+            settings = new PluginUpdateSettings(settings.autoUpdateEnabled(), behaviour, settings.retainUpstreamFilename());
+            mutated = true;
+        }
+
+        if (retainFilename != null) {
+            settings = new PluginUpdateSettings(settings.autoUpdateEnabled(), settings.behaviour(), retainFilename);
+            mutated = true;
+        }
+
+        return mutated ? settings : null;
     }
 
     private Integer toInteger(Object value, String pluginKey) {
@@ -134,6 +240,34 @@ public class LegacyConfigMigrator {
         return null;
     }
 
+    private Boolean toBoolean(Object value, String pluginKey, String field) {
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        if (value instanceof String string) {
+            String trimmed = string.trim();
+            if ("true".equalsIgnoreCase(trimmed)) {
+                return Boolean.TRUE;
+            }
+            if ("false".equalsIgnoreCase(trimmed)) {
+                return Boolean.FALSE;
+            }
+            logger.log(Level.WARNING,
+                    "Unable to parse boolean value '{0}' for field {1} of legacy plugin entry {2}",
+                    new Object[]{string, field, pluginKey});
+            return null;
+        }
+        if (value != null) {
+            logger.log(Level.WARNING,
+                    "Ignoring non-boolean value for field {0} of legacy plugin entry {1}",
+                    new Object[]{field, pluginKey});
+        }
+        return null;
+    }
+
     private record LegacyPluginState(Integer build, String version) {
+    }
+
+    private record LegacyPluginData(LegacyPluginState state, PluginUpdateSettings settings) {
     }
 }

--- a/src/test/java/eu/nurkert/neverUp2Late/persistence/LegacyConfigMigratorTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/persistence/LegacyConfigMigratorTest.java
@@ -1,0 +1,70 @@
+package eu.nurkert.neverUp2Late.persistence;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LegacyConfigMigratorTest {
+
+    private final Logger logger = Logger.getLogger("test");
+
+    @Test
+    void migratesLegacyPluginStateAndSettings(@TempDir Path tempDir) {
+        UpdateStateRepository stateRepository = new UpdateStateRepository(tempDir.toFile(), logger);
+        PluginUpdateSettingsRepository settingsRepository = new PluginUpdateSettingsRepository(tempDir.toFile(), logger);
+
+        YamlConfiguration configuration = new YamlConfiguration();
+        ConfigurationSection pluginsSection = configuration.createSection("plugins");
+        ConfigurationSection paperSection = pluginsSection.createSection("paper");
+        paperSection.set("build", 42);
+        paperSection.set("version", "1.2.3");
+        paperSection.set("autoUpdate", false);
+        paperSection.set("behaviour", "AUTO_RELOAD");
+        paperSection.set("retainUpstreamFilename", true);
+
+        LegacyConfigMigrator migrator = new LegacyConfigMigrator(configuration, stateRepository, settingsRepository, logger);
+
+        assertTrue(migrator.migrate(), "Expected migration to mutate configuration");
+        assertFalse(configuration.contains("plugins"), "Legacy plugins section should be removed");
+
+        Optional<UpdateStateRepository.PluginState> state = stateRepository.find("paper");
+        assertTrue(state.isPresent());
+        assertEquals(42, state.get().build());
+        assertEquals("1.2.3", state.get().version());
+
+        PluginUpdateSettingsRepository.PluginUpdateSettings settings = settingsRepository.getSettings("paper");
+        assertFalse(settings.autoUpdateEnabled());
+        assertEquals(PluginUpdateSettingsRepository.UpdateBehaviour.AUTO_RELOAD, settings.behaviour());
+        assertTrue(settings.retainUpstreamFilename());
+    }
+
+    @Test
+    void ignoresUnsupportedLegacyValues(@TempDir Path tempDir) {
+        UpdateStateRepository stateRepository = new UpdateStateRepository(tempDir.toFile(), logger);
+        PluginUpdateSettingsRepository settingsRepository = new PluginUpdateSettingsRepository(tempDir.toFile(), logger);
+
+        YamlConfiguration configuration = new YamlConfiguration();
+        ConfigurationSection pluginsSection = configuration.createSection("plugins");
+        pluginsSection.set("geyser", 77);
+        pluginsSection.set("invalid", new Object());
+
+        LegacyConfigMigrator migrator = new LegacyConfigMigrator(configuration, stateRepository, settingsRepository, logger);
+
+        assertTrue(migrator.migrate());
+        assertFalse(configuration.contains("plugins"));
+
+        Optional<UpdateStateRepository.PluginState> state = stateRepository.find("geyser");
+        assertTrue(state.isPresent());
+        assertEquals(77, state.get().build());
+
+        PluginUpdateSettingsRepository.PluginUpdateSettings settings = settingsRepository.getSettings("geyser");
+        assertEquals(PluginUpdateSettingsRepository.PluginUpdateSettings.defaultSettings(), settings);
+    }
+}


### PR DESCRIPTION
## Summary
- migrate legacy plugin entries in `config.yml` to `plugins.yml` and `plugin-settings.yml`
- initialize the plugin update settings repository prior to migration so legacy values can be persisted
- add unit tests covering migration of legacy plugin state and settings

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68dea6bfcf1c8322acf99787b884470f