### PR TITLE
Gracefully stop update checks during plugin shutdown

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -99,7 +99,13 @@ public final class NeverUp2Late extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (context != null) {
+            try {
+                context.getUpdateHandler().stop();
+            } catch (Exception ex) {
+                getLogger().log(java.util.logging.Level.FINE, "Failed to stop update handler during shutdown", ex);
+            }
+        }
     }
 
     public PluginContext getContext() {


### PR DESCRIPTION
## Summary
- add shutdown tracking to UpdateHandler so scheduled update checks are cancelled safely
- stop the UpdateHandler during plugin disable to prevent classloader zip errors

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68deacc17c4083229bcbc061f8392719