### PR TITLE
Fix GUI inventory session handling

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
@@ -537,6 +537,11 @@ public class PluginOverviewGui implements Listener {
             return;
         }
 
+        if (event.getInventory().getType() == InventoryType.ANVIL) {
+            handleRenameClick(player, event);
+            return;
+        }
+
         InventorySession session = openInventories.get(player.getUniqueId());
         if (session == null) {
             return;
@@ -552,11 +557,6 @@ public class PluginOverviewGui implements Listener {
         }
 
         event.setCancelled(true);
-
-        if (event.getInventory().getType() == InventoryType.ANVIL) {
-            handleRenameClick(player, event);
-            return;
-        }
 
         if (session.view() == View.OVERVIEW) {
             int installSlot = session.inventory().getSize() - 1;
@@ -615,7 +615,11 @@ public class PluginOverviewGui implements Listener {
 
     @EventHandler
     public void onInventoryClose(InventoryCloseEvent event) {
-        openInventories.remove(event.getPlayer().getUniqueId());
+        UUID playerId = event.getPlayer().getUniqueId();
+        InventorySession session = openInventories.get(playerId);
+        if (session != null && event.getInventory().equals(session.inventory())) {
+            openInventories.remove(playerId);
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- ensure rename anvils are handled even when no overview session is tracked
- keep the active GUI session while switching between overview and detail views to preserve click handling

## Testing
- mvn -B -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68deaf512b3c8322a3dd71bbc9e8c6de