### PR TITLE
Fix Modrinth slug parsing for category URLs

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -56,6 +56,25 @@ import java.util.logging.Logger;
 
 public class QuickInstallCoordinator {
 
+    private static final Set<String> MODRINTH_SEGMENT_PREFIXES = Set.of(
+            "plugin",
+            "plugins",
+            "project",
+            "projects",
+            "mod",
+            "mods",
+            "modpack",
+            "modpacks",
+            "datapack",
+            "datapacks",
+            "resourcepack",
+            "resourcepacks",
+            "shaderpack",
+            "shaderpacks",
+            "shader",
+            "shaders"
+    );
+
     private final JavaPlugin plugin;
     private final BukkitScheduler scheduler;
     private final FileConfiguration configuration;
@@ -565,12 +584,14 @@ public class QuickInstallCoordinator {
                 continue;
             }
 
+            String normalized = segment.toLowerCase(Locale.ROOT);
+
             if (expectSlug) {
                 slug = segment;
                 break;
             }
 
-            if (segment.equalsIgnoreCase("plugin") || segment.equalsIgnoreCase("project")) {
+            if (MODRINTH_SEGMENT_PREFIXES.contains(normalized)) {
                 expectSlug = true;
                 continue;
             }

--- a/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
@@ -28,6 +28,14 @@ class QuickInstallCoordinatorTest {
     }
 
     @Test
+    void extractModrinthSlugIgnoresCategorySegments() {
+        Optional<String> slug = QuickInstallCoordinator.extractModrinthSlug(List.of("datapack", "veinminer"));
+
+        assertTrue(slug.isPresent());
+        assertEquals("veinminer", slug.orElseThrow());
+    }
+
+    @Test
     void extractModrinthSlugDecodesUrlEncodedSegments() {
         Optional<String> slug = QuickInstallCoordinator.extractModrinthSlug(List.of("plugin", "My%20Plugin"));
 


### PR DESCRIPTION
## Summary
- ignore common Modrinth category path prefixes so slug extraction works for datapacks and similar URLs
- cover the datapack URL format with a new QuickInstallCoordinator test

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68deb4bb83f48322b46f7ff4bd60d76a