### PR TITLE
Enable GUI by default

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -37,7 +37,7 @@ public final class NeverUp2Late extends JavaPlugin {
         }
 
         PersistentPluginHandler persistentPluginHandler = new PersistentPluginHandler(updateStateRepository);
-        boolean lifecycleEnabled = configuration.getBoolean("pluginLifecycle.autoManage", false);
+        boolean lifecycleEnabled = configuration.getBoolean("pluginLifecycle.autoManage", true);
         PluginLifecycleManager pluginLifecycleManager = null;
         if (lifecycleEnabled) {
             pluginLifecycleManager = new PluginManagerApi(

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,8 +10,8 @@ updateInterval: 30
 # Controls automatic plugin lifecycle operations (reload/unload).
 pluginLifecycle:
   # When true, NeverUp2Late will attempt to reload updated plugins automatically.
-  # The default is false to avoid interfering with plugins that do not support reloads.
-  autoManage: false
+  # The default is now true so the GUI is usable without manual configuration.
+  autoManage: true
 
 # Ignore unstable builds (legacy location, still respected if updates.ignoreUnstable is absent)
 ignoreUnstable: true


### PR DESCRIPTION
## Summary
- default plugin lifecycle management to enabled so the GUI can open without extra setup
- update configuration comments to reflect the new default behaviour

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dec3df608c832297b5521b07a8b527