### PR TITLE
Translate user-facing text to English

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
@@ -28,24 +28,24 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0 || "gui".equalsIgnoreCase(args[0])) {
             if (!sender.hasPermission(Permissions.GUI_OPEN)) {
-                sender.sendMessage(ChatColor.RED + "Dir fehlt die Berechtigung, die GUI zu öffnen.");
+                sender.sendMessage(ChatColor.RED + "You do not have permission to open the GUI.");
                 return true;
             }
             if (sender instanceof Player player) {
                 overviewGui.open(player);
             } else {
-                sender.sendMessage(ChatColor.RED + "Die grafische Oberfläche kann nur von Spielern geöffnet werden.");
+                sender.sendMessage(ChatColor.RED + "The graphical interface can only be opened by players.");
             }
             return true;
         }
 
         if (args.length > 0 && "select".equalsIgnoreCase(args[0])) {
             if (!sender.hasPermission(Permissions.INSTALL)) {
-                sender.sendMessage(ChatColor.RED + "Dir fehlt die Berechtigung, Installationen zu verwalten.");
+                sender.sendMessage(ChatColor.RED + "You do not have permission to manage installations.");
                 return true;
             }
             if (args.length < 2) {
-                sender.sendMessage(ChatColor.RED + "Bitte gib die Nummer der gewünschten Datei an.");
+                sender.sendMessage(ChatColor.RED + "Please specify the number of the desired file.");
                 return true;
             }
             coordinator.handleAssetSelection(sender, args[1]);
@@ -54,11 +54,11 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
 
         if (args.length > 0 && "remove".equalsIgnoreCase(args[0])) {
             if (!sender.hasPermission(Permissions.GUI_MANAGE_REMOVE)) {
-                sender.sendMessage(ChatColor.RED + "Dir fehlt die Berechtigung, Plugins zu entfernen.");
+                sender.sendMessage(ChatColor.RED + "You do not have permission to remove plugins.");
                 return true;
             }
             if (args.length < 2) {
-                sender.sendMessage(ChatColor.RED + "Bitte gib den Namen des Plugins an.");
+                sender.sendMessage(ChatColor.RED + "Please provide the plugin name.");
                 return true;
             }
             String pluginName = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
@@ -67,13 +67,13 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
         }
 
         if (!sender.hasPermission(Permissions.INSTALL)) {
-            sender.sendMessage(ChatColor.RED + "Dir fehlt die Berechtigung, Installationen zu verwalten.");
+            sender.sendMessage(ChatColor.RED + "You do not have permission to manage installations.");
             return true;
         }
 
         String url = String.join(" ", args).trim();
         if (url.isEmpty()) {
-            sender.sendMessage(ChatColor.RED + "Bitte gib eine gültige URL an.");
+            sender.sendMessage(ChatColor.RED + "Please provide a valid URL.");
             return true;
         }
 
@@ -87,7 +87,7 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
             return List.of("gui", "select", "remove");
         }
         if (args.length == 2 && "select".equalsIgnoreCase(args[0])) {
-            return Collections.singletonList("<nummer>");
+            return Collections.singletonList("<number>");
         }
         return Collections.emptyList();
     }

--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -118,7 +118,7 @@ public class QuickInstallCoordinator {
         }
         String url = rawUrl != null ? rawUrl.trim() : "";
         if (url.isEmpty()) {
-            send(sender, ChatColor.RED + "Bitte gib eine gültige URL an.");
+            send(sender, ChatColor.RED + "Please provide a valid URL.");
             return;
         }
 
@@ -128,7 +128,7 @@ public class QuickInstallCoordinator {
         try {
             uri = new URI(url);
         } catch (URISyntaxException e) {
-            send(sender, ChatColor.RED + "Die URL ist ungültig: " + e.getMessage());
+            send(sender, ChatColor.RED + "The URL is invalid: " + e.getMessage());
             return;
         }
 
@@ -143,21 +143,21 @@ public class QuickInstallCoordinator {
         plan.setSourceName(ensureUniqueName(plan.getSuggestedName()));
         if (forcedPluginName != null && !forcedPluginName.isBlank()) {
             plan.setInstalledPluginName(forcedPluginName);
-            send(sender, ChatColor.GRAY + "Verknüpfe mit ausgewähltem Plugin: " + forcedPluginName);
+            send(sender, ChatColor.GRAY + "Linking with selected plugin: " + forcedPluginName);
         } else {
             detectInstalledPlugin(plan).ifPresent(installed -> {
                 plan.setInstalledPluginName(installed);
-                send(sender, ChatColor.GRAY + "Verknüpfe mit installiertem Plugin: " + installed);
+                send(sender, ChatColor.GRAY + "Linking with installed plugin: " + installed);
             });
         }
 
-        send(sender, ChatColor.AQUA + "Quelle erkannt: " + plan.getDisplayName() + " (" + plan.getProvider() + ")");
+        send(sender, ChatColor.AQUA + "Detected source: " + plan.getDisplayName() + " (" + plan.getProvider() + ")");
 
         scheduler.runTaskAsynchronously(plugin, () -> prepareAndInstall(sender, plan));
     }
 
     private void prepareAndInstall(CommandSender sender, InstallationPlan plan) {
-        send(sender, ChatColor.YELLOW + "Lade Versionsinformationen …");
+        send(sender, ChatColor.YELLOW + "Loading version information…");
         eu.nurkert.neverUp2Late.fetcher.UpdateFetcher fetcher;
         try {
             fetcher = updateSourceRegistry.createFetcher(plan.getFetcherType(), plan.getOptions());
@@ -173,7 +173,7 @@ public class QuickInstallCoordinator {
             return;
         } catch (Exception e) {
             logger.log(Level.WARNING, "Failed to prepare installation for " + plan.getDisplayName(), e);
-            send(sender, ChatColor.RED + "Fehler beim Laden der Versionsinformationen: " + e.getMessage());
+            send(sender, ChatColor.RED + "Failed to load version information: " + e.getMessage());
             return;
         }
 
@@ -181,7 +181,7 @@ public class QuickInstallCoordinator {
             return;
         }
 
-        send(sender, ChatColor.GREEN + "Neueste Version: " + plan.getLatestVersionInfo());
+        send(sender, ChatColor.GREEN + "Latest version: " + plan.getLatestVersionInfo());
 
         scheduler.runTask(plugin, () -> finalizeInstallation(sender, plan));
     }
@@ -191,7 +191,7 @@ public class QuickInstallCoordinator {
             return;
         }
         if (selectionInput == null || selectionInput.isBlank()) {
-            send(sender, ChatColor.RED + "Bitte gib die Nummer der gewünschten Datei an.");
+            send(sender, ChatColor.RED + "Please specify the number of the desired file.");
             return;
         }
 
@@ -206,12 +206,12 @@ public class QuickInstallCoordinator {
         try {
             index = Integer.parseInt(selectionInput.trim());
         } catch (NumberFormatException ex) {
-            send(sender, ChatColor.RED + "Bitte gib eine gültige Nummer an.");
+            send(sender, ChatColor.RED + "Please enter a valid number.");
             return;
         }
 
         if (index < 1 || index > pending.assets().size()) {
-            send(sender, ChatColor.RED + "Ungültige Auswahl. Bitte wähle eine Zahl zwischen 1 und " + pending.assets().size() + ".");
+            send(sender, ChatColor.RED + "Invalid selection. Please choose a number between 1 and " + pending.assets().size() + ".");
             return;
         }
 
@@ -225,9 +225,9 @@ public class QuickInstallCoordinator {
         pending.plan().getOptions().put("assetPattern", pattern);
         pendingSelections.remove(key);
 
-        send(sender, ChatColor.GREEN + "Verwende Asset \"" + assetName + "\". Regex wurde automatisch erstellt.");
+        send(sender, ChatColor.GREEN + "Using asset \"" + assetName + "\". Regex created automatically.");
         if (asset.archive()) {
-            send(sender, ChatColor.GOLD + "Hinweis: Das ausgewählte Asset ist ein Archiv. NU2L extrahiert automatisch die passende JAR-Datei.");
+            send(sender, ChatColor.GOLD + "Note: The selected asset is an archive. NU2L will automatically extract the matching JAR file.");
         }
 
         scheduler.runTaskAsynchronously(plugin, () -> prepareAndInstall(sender, pending.plan()));
@@ -236,7 +236,7 @@ public class QuickInstallCoordinator {
     private void handleArchiveSelection(CommandSender sender, String selectionInput, String key) {
         ArchivePendingSelection pending = pendingArchiveSelections.get(key);
         if (pending == null) {
-            send(sender, ChatColor.RED + "Es gibt keine offene Auswahl.");
+            send(sender, ChatColor.RED + "There is no pending selection.");
             return;
         }
 
@@ -244,12 +244,12 @@ public class QuickInstallCoordinator {
         try {
             index = Integer.parseInt(selectionInput.trim());
         } catch (NumberFormatException ex) {
-            send(sender, ChatColor.RED + "Bitte gib eine gültige Nummer an.");
+            send(sender, ChatColor.RED + "Please enter a valid number.");
             return;
         }
 
         if (index < 1 || index > pending.entries().size()) {
-            send(sender, ChatColor.RED + "Ungültige Auswahl. Bitte wähle eine Zahl zwischen 1 und " + pending.entries().size() + ".");
+            send(sender, ChatColor.RED + "Invalid selection. Please choose a number between 1 and " + pending.entries().size() + ".");
             return;
         }
 
@@ -261,7 +261,7 @@ public class QuickInstallCoordinator {
         pending.plan().setFilename(extractFileNameForArchive(selected));
         pendingArchiveSelections.remove(key);
 
-        send(sender, ChatColor.GREEN + "Verwende JAR \"" + selected.fullPath() + "\" aus dem Archiv.");
+        send(sender, ChatColor.GREEN + "Using JAR \"" + selected.fullPath() + "\" from the archive.");
         scheduler.runTaskAsynchronously(plugin, () -> prepareAndInstall(sender, pending.plan()));
     }
 
@@ -275,7 +275,7 @@ public class QuickInstallCoordinator {
 
         String downloadUrl = plan.getDownloadUrl();
         if (downloadUrl == null || downloadUrl.isBlank()) {
-            send(sender, ChatColor.RED + "Fehler: Archiv-Download-URL fehlt.");
+            send(sender, ChatColor.RED + "Error: archive download URL missing.");
             return false;
         }
 
@@ -284,12 +284,12 @@ public class QuickInstallCoordinator {
             entries = inspectArchive(downloadUrl);
         } catch (IOException e) {
             logger.log(Level.WARNING, "Failed to inspect archive for " + plan.getDisplayName(), e);
-            send(sender, ChatColor.RED + "Fehler beim Auswerten des Archivs: " + e.getMessage());
+            send(sender, ChatColor.RED + "Failed to inspect archive: " + e.getMessage());
             return false;
         }
 
         if (entries.isEmpty()) {
-            send(sender, ChatColor.RED + "Das Archiv enthält keine JAR-Dateien.");
+            send(sender, ChatColor.RED + "The archive does not contain any JAR files.");
             return false;
         }
 
@@ -311,7 +311,7 @@ public class QuickInstallCoordinator {
 
         if (entries.size() == 1) {
             applyArchiveSelection(plan, entries.get(0), entries);
-            send(sender, ChatColor.GRAY + "Finde JAR im Archiv: " + entries.get(0).fullPath());
+            send(sender, ChatColor.GRAY + "Found JAR in archive: " + entries.get(0).fullPath());
             return true;
         }
 
@@ -348,13 +348,13 @@ public class QuickInstallCoordinator {
         String key = selectionKey(sender);
         pendingArchiveSelections.put(key, new ArchivePendingSelection(plan, List.copyOf(entries)));
 
-        send(sender, ChatColor.GOLD + "Das Archiv enthält mehrere JAR-Dateien:");
+        send(sender, ChatColor.GOLD + "The archive contains multiple JAR files:");
         for (int i = 0; i < entries.size(); i++) {
             ArchiveEntry entry = entries.get(i);
             send(sender, ChatColor.GRAY + String.valueOf(i + 1) + ChatColor.DARK_GRAY + ". "
                     + ChatColor.AQUA + entry.fullPath());
         }
-        send(sender, ChatColor.YELLOW + "Bitte wähle mit /nu2l select <Nummer> die gewünschte Datei aus.");
+        send(sender, ChatColor.YELLOW + "Please use /nu2l select <number> to choose the desired file.");
     }
 
     private String extractFileNameForArchive(ArchiveEntry entry) {
@@ -373,31 +373,31 @@ public class QuickInstallCoordinator {
         pendingSelections.put(key, new PendingSelection(plan, selection.getAssets(), selection.getAssetType(), selection.getReleaseTag()));
 
         String typeLabel = switch (selection.getAssetType()) {
-            case ARCHIVE -> "Archive";
-            case JAR -> "JAR-Dateien";
-            default -> "Assets";
+            case ARCHIVE -> "archives";
+            case JAR -> "JAR files";
+            default -> "assets";
         };
 
-        send(sender, ChatColor.GOLD + "Mehrere " + typeLabel + " gefunden für " + plan.getDisplayName()
+        send(sender, ChatColor.GOLD + "Found multiple " + typeLabel + " for " + plan.getDisplayName()
                 + " (" + selection.getReleaseTag() + "):");
         List<AssetSelectionRequiredException.ReleaseAsset> assets = selection.getAssets();
         for (int i = 0; i < assets.size(); i++) {
             AssetSelectionRequiredException.ReleaseAsset asset = assets.get(i);
             String label = assetLabel(asset);
-            String suffix = asset.archive() ? ChatColor.YELLOW + " (Archiv)" : "";
+            String suffix = asset.archive() ? ChatColor.YELLOW + " (archive)" : "";
             send(sender, ChatColor.GRAY + String.valueOf(i + 1) + ChatColor.DARK_GRAY + ". "
                     + ChatColor.AQUA + label + suffix);
         }
-        send(sender, ChatColor.YELLOW + "Bitte wähle mit /nu2l select <Nummer> das gewünschte Asset aus.");
+        send(sender, ChatColor.YELLOW + "Please use /nu2l select <number> to choose the desired asset.");
         if (selection.getAssetType() == AssetSelectionRequiredException.AssetType.ARCHIVE
                 || assets.stream().anyMatch(AssetSelectionRequiredException.ReleaseAsset::archive)) {
-            send(sender, ChatColor.GOLD + "Hinweis: Archive werden automatisch entpackt, bitte wähle die gewünschte Datei.");
+            send(sender, ChatColor.GOLD + "Note: Archives are extracted automatically; please choose the desired file.");
         }
     }
 
     private void finalizeInstallation(CommandSender sender, InstallationPlan plan) {
         if (updateSourceRegistry.hasSource(plan.getSourceName())) {
-            send(sender, ChatColor.YELLOW + "Quelle existiert bereits, starte Aktualisierung …");
+            send(sender, ChatColor.YELLOW + "Source already exists, starting update…");
             UpdateSource existing = updateSourceRegistry.findSource(plan.getSourceName()).orElse(null);
             if (existing != null) {
                 updateHandler.runJobNow(existing, sender);
@@ -418,11 +418,11 @@ public class QuickInstallCoordinator {
             );
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Failed to register dynamic source " + plan.getSourceName(), e);
-            send(sender, ChatColor.RED + "Konnte Quelle nicht registrieren: " + e.getMessage());
+            send(sender, ChatColor.RED + "Could not register source: " + e.getMessage());
             return;
         }
 
-        send(sender, ChatColor.GREEN + "Installation wird gestartet …");
+        send(sender, ChatColor.GREEN + "Starting installation…");
         updateHandler.runJobNow(source, sender);
     }
 
@@ -517,13 +517,13 @@ public class QuickInstallCoordinator {
         if (uri.getPath() != null && uri.getPath().toLowerCase(Locale.ROOT).contains("/job/")) {
             return buildJenkinsPlan(uri, originalUrl, host);
         }
-        throw new IllegalArgumentException("Diese URL wird aktuell nicht unterstützt.");
+        throw new IllegalArgumentException("This URL is not currently supported.");
     }
 
     private InstallationPlan buildHangarPlan(URI uri, String originalUrl, String host) {
         List<String> segments = pathSegments(uri.getPath());
         OwnerSlug ownerSlug = extractOwnerAndSlug(segments, List.of("plugins", "plugin", "project"))
-                .orElseThrow(() -> new IllegalArgumentException("Hangar-URL muss das Format /Owner/Projekt haben."));
+                .orElseThrow(() -> new IllegalArgumentException("Hangar URL must follow the /Owner/Project format."));
         String owner = ownerSlug.owner();
         String slug = ownerSlug.slug();
         Map<String, Object> options = new LinkedHashMap<>();
@@ -552,7 +552,7 @@ public class QuickInstallCoordinator {
     private InstallationPlan buildModrinthPlan(URI uri, String originalUrl, String host) {
         List<String> segments = pathSegments(uri.getPath());
         String slug = extractModrinthSlug(segments)
-                .orElseThrow(() -> new IllegalArgumentException("Modrinth-URL konnte nicht ausgewertet werden."));
+                .orElseThrow(() -> new IllegalArgumentException("Could not parse Modrinth URL."));
 
         Map<String, Object> options = new LinkedHashMap<>();
         options.put("project", slug);
@@ -656,7 +656,7 @@ public class QuickInstallCoordinator {
     private InstallationPlan buildGithubPlan(URI uri, String originalUrl, String host) {
         List<String> segments = pathSegments(uri.getPath());
         OwnerSlug ownerSlug = extractOwnerAndSlug(segments, List.of("repos", "projects", "users", "orgs"))
-                .orElseThrow(() -> new IllegalArgumentException("GitHub-URL muss das Format /Owner/Repository haben."));
+                .orElseThrow(() -> new IllegalArgumentException("GitHub URL must follow the /Owner/Repository format."));
         String owner = ownerSlug.owner();
         String repository = ownerSlug.slug();
 
@@ -691,7 +691,7 @@ public class QuickInstallCoordinator {
             }
         }
         if (jobSegments.isEmpty()) {
-            throw new IllegalArgumentException("Jenkins-URL muss /job/<Name> enthalten.");
+            throw new IllegalArgumentException("Jenkins URL must contain /job/<name>.");
         }
 
         String jobPath = String.join("/", jobSegments);
@@ -800,20 +800,20 @@ public class QuickInstallCoordinator {
         if (sender.hasPermission(permission)) {
             return true;
         }
-        send(sender, ChatColor.RED + "Dir fehlt die Berechtigung (" + permission + ").");
+        send(sender, ChatColor.RED + "You do not have the required permission (" + permission + ").");
         return false;
     }
 
     public void removeManagedPlugin(CommandSender sender, ManagedPlugin target) {
         if (target == null) {
-            send(sender, ChatColor.RED + "Unbekanntes Plugin – Aktion abgebrochen.");
+            send(sender, ChatColor.RED + "Unknown plugin – action cancelled.");
             return;
         }
         if (!hasPermission(sender, Permissions.GUI_MANAGE_REMOVE)) {
             return;
         }
         if (pluginLifecycleManager == null) {
-            send(sender, ChatColor.RED + "Die Plugin-Verwaltung ist deaktiviert; Entfernen nicht möglich.");
+            send(sender, ChatColor.RED + "Plugin management is disabled; removal not possible.");
             return;
         }
 
@@ -829,7 +829,7 @@ public class QuickInstallCoordinator {
                     pluginLifecycleManager.unloadPlugin(pluginName);
                 }
             } catch (PluginLifecycleException ex) {
-                send(sender, ChatColor.RED + "Fehler beim Entladen von " + pluginName + ": " + ex.getMessage());
+                send(sender, ChatColor.RED + "Failed to unload " + pluginName + ": " + ex.getMessage());
                 logger.log(Level.WARNING, "Failed to unload plugin " + pluginName, ex);
                 return;
             }
@@ -838,7 +838,7 @@ public class QuickInstallCoordinator {
                 try {
                     Files.deleteIfExists(jarPath);
                 } catch (IOException ex) {
-                    send(sender, ChatColor.RED + "Konnte Datei nicht löschen: " + jarPath.getFileName());
+                    send(sender, ChatColor.RED + "Could not delete file: " + jarPath.getFileName());
                     logger.log(Level.WARNING, "Failed to delete plugin jar " + jarPath, ex);
                     return;
                 }
@@ -863,7 +863,7 @@ public class QuickInstallCoordinator {
                 pluginUpdateSettingsRepository.removeSettings(pluginName);
             }
 
-            send(sender, ChatColor.GREEN + "Plugin " + ChatColor.AQUA + pluginName + ChatColor.GREEN + " wurde entfernt.");
+            send(sender, ChatColor.GREEN + "Plugin " + ChatColor.AQUA + pluginName + ChatColor.GREEN + " has been removed.");
         });
     }
 
@@ -883,12 +883,12 @@ public class QuickInstallCoordinator {
 
     public void removePlugin(CommandSender sender, String pluginName) {
         if (pluginLifecycleManager == null) {
-            send(sender, ChatColor.RED + "Die Plugin-Verwaltung ist deaktiviert; Entfernen nicht möglich.");
+            send(sender, ChatColor.RED + "Plugin management is disabled; removal not possible.");
             return;
         }
         ManagedPlugin target = pluginLifecycleManager.findByName(pluginName).orElse(null);
         if (target == null) {
-            send(sender, ChatColor.RED + "Plugin " + pluginName + " wurde nicht gefunden.");
+            send(sender, ChatColor.RED + "Plugin " + pluginName + " was not found.");
             return;
         }
         removeManagedPlugin(sender, target);
@@ -896,7 +896,7 @@ public class QuickInstallCoordinator {
 
     public void disableAutomaticUpdates(CommandSender sender, ManagedPlugin target) {
         if (target == null) {
-            send(sender, ChatColor.RED + "Unbekanntes Plugin – Aktion abgebrochen.");
+            send(sender, ChatColor.RED + "Unknown plugin – action cancelled.");
             return;
         }
         if (!hasPermission(sender, Permissions.GUI_MANAGE_LINK)) {
@@ -914,8 +914,8 @@ public class QuickInstallCoordinator {
         String displayName = pluginName.isBlank() ? "Plugin" : pluginName;
 
         if (matchingSources.isEmpty()) {
-            send(sender, ChatColor.YELLOW + "Für " + ChatColor.AQUA + displayName
-                    + ChatColor.YELLOW + " ist keine Update-Quelle hinterlegt.");
+            send(sender, ChatColor.YELLOW + "No update source is configured for "
+                    + ChatColor.AQUA + displayName + ChatColor.YELLOW + ".");
             return;
         }
 
@@ -952,52 +952,52 @@ public class QuickInstallCoordinator {
         }
 
         if (removed > 0) {
-            send(sender, ChatColor.YELLOW + "Automatische Updates für " + ChatColor.AQUA + displayName
-                    + ChatColor.YELLOW + " wurden deaktiviert.");
-            send(sender, ChatColor.GRAY + "Das Plugin bleibt installiert, nur die Update-Quelle wurde entfernt.");
+            send(sender, ChatColor.YELLOW + "Automatic updates for " + ChatColor.AQUA + displayName
+                    + ChatColor.YELLOW + " have been disabled.");
+            send(sender, ChatColor.GRAY + "The plugin remains installed; only the update source was removed.");
         } else {
-            send(sender, ChatColor.RED + "Automatische Updates konnten nicht deaktiviert werden.");
+            send(sender, ChatColor.RED + "Could not disable automatic updates.");
         }
     }
 
     public void renameManagedPlugin(CommandSender sender, ManagedPlugin target, String requestedName) {
         if (target == null) {
-            send(sender, ChatColor.RED + "Unbekanntes Plugin – Aktion abgebrochen.");
+            send(sender, ChatColor.RED + "Unknown plugin – action cancelled.");
             return;
         }
         if (!hasPermission(sender, Permissions.GUI_MANAGE_RENAME)) {
             return;
         }
         if (pluginLifecycleManager == null) {
-            send(sender, ChatColor.RED + "Die Plugin-Verwaltung ist deaktiviert; Umbenennung nicht möglich.");
+            send(sender, ChatColor.RED + "Plugin management is disabled; rename not possible.");
             return;
         }
 
         scheduler.runTask(plugin, () -> {
             Path currentPath = target.getPath();
             if (currentPath == null) {
-                send(sender, ChatColor.RED + "Es konnte kein Dateipfad ermittelt werden.");
+                send(sender, ChatColor.RED + "Could not determine a file path.");
                 return;
             }
 
             String sanitized = FileNameSanitizer.sanitizeJarFilename(requestedName);
             if (sanitized == null) {
-                send(sender, ChatColor.RED + "Bitte gib einen gültigen Dateinamen an.");
+                send(sender, ChatColor.RED + "Please provide a valid file name.");
                 return;
             }
 
             Path parent = currentPath.getParent();
             if (parent == null) {
-                send(sender, ChatColor.RED + "Konnte Zielverzeichnis nicht bestimmen.");
+                send(sender, ChatColor.RED + "Could not determine target directory.");
                 return;
             }
             Path targetPath = parent.resolve(sanitized).toAbsolutePath().normalize();
             if (targetPath.equals(currentPath)) {
-                send(sender, ChatColor.GRAY + "Der Dateiname bleibt unverändert.");
+                send(sender, ChatColor.GRAY + "The file name remains unchanged.");
                 return;
             }
             if (Files.exists(targetPath)) {
-                send(sender, ChatColor.RED + "Eine Datei mit diesem Namen existiert bereits: " + targetPath.getFileName());
+                send(sender, ChatColor.RED + "A file with that name already exists: " + targetPath.getFileName());
                 return;
             }
 
@@ -1013,7 +1013,7 @@ public class QuickInstallCoordinator {
                     pluginLifecycleManager.unloadPlugin(pluginName);
                 }
             } catch (PluginLifecycleException ex) {
-                send(sender, ChatColor.RED + "Fehler beim Entladen von " + pluginName + ": " + ex.getMessage());
+                send(sender, ChatColor.RED + "Failed to unload " + pluginName + ": " + ex.getMessage());
                 logger.log(Level.WARNING, "Failed to unload plugin for rename " + pluginName, ex);
                 return;
             }
@@ -1026,12 +1026,12 @@ public class QuickInstallCoordinator {
                 try {
                     Files.move(currentPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException inner) {
-                    send(sender, ChatColor.RED + "Umbenennen fehlgeschlagen: " + inner.getMessage());
+                    send(sender, ChatColor.RED + "Rename failed: " + inner.getMessage());
                     logger.log(Level.WARNING, "Failed to rename plugin jar", inner);
                     return;
                 }
             } catch (IOException ex) {
-                send(sender, ChatColor.RED + "Umbenennen fehlgeschlagen: " + ex.getMessage());
+                send(sender, ChatColor.RED + "Rename failed: " + ex.getMessage());
                 logger.log(Level.WARNING, "Failed to rename plugin jar", ex);
                 return;
             }
@@ -1058,13 +1058,13 @@ public class QuickInstallCoordinator {
                         pluginLifecycleManager.enablePlugin(pluginName);
                     }
                 } catch (PluginLifecycleException ex) {
-                    send(sender, ChatColor.YELLOW + "Plugin wurde umbenannt, konnte aber nicht neu geladen werden: " + ex.getMessage());
+                    send(sender, ChatColor.YELLOW + "Plugin was renamed but could not be reloaded: " + ex.getMessage());
                     logger.log(Level.WARNING, "Failed to reload plugin after rename", ex);
                     return;
                 }
             }
 
-            send(sender, ChatColor.GREEN + "Plugin-Datei in " + ChatColor.AQUA + sanitized + ChatColor.GREEN + " umbenannt.");
+            send(sender, ChatColor.GREEN + "Renamed plugin file to " + ChatColor.AQUA + sanitized + ChatColor.GREEN + ".");
         });
     }
 
@@ -1087,7 +1087,7 @@ public class QuickInstallCoordinator {
 
     private String assetLabel(AssetSelectionRequiredException.ReleaseAsset asset) {
         if (asset == null) {
-            return "Unbekannt";
+            return "Unknown";
         }
         String name = trimToNull(asset.name());
         if (name != null) {

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/GithubReleaseFetcher.java
@@ -432,7 +432,7 @@ public class GithubReleaseFetcher extends JsonUpdateFetcher {
         public Path process(UpdateContext context, Path downloadedFile) throws IOException {
             List<ArchiveEntry> entries = ArchiveUtils.listJarEntries(downloadedFile);
             if (entries.isEmpty()) {
-                throw new IOException("Das Archiv enthält keine JAR-Dateien: " + downloadedFile);
+                throw new IOException("The archive does not contain any JAR files: " + downloadedFile);
             }
 
             ArchiveEntry selected = selectEntry(entries);
@@ -458,7 +458,7 @@ public class GithubReleaseFetcher extends JsonUpdateFetcher {
                         .filter(entry -> entryPattern.matcher(entry.fullPath()).matches()
                                 || entryPattern.matcher(entry.fileName()).matches())
                         .findFirst()
-                        .orElseThrow(() -> new IOException("Keine zur Regex passende JAR im Archiv gefunden: "
+                        .orElseThrow(() -> new IOException("No JAR in the archive matched the regex: "
                                 + entryPattern.pattern()));
             }
             if (entries.size() == 1) {
@@ -467,7 +467,7 @@ public class GithubReleaseFetcher extends JsonUpdateFetcher {
             String candidates = entries.stream()
                     .map(ArchiveEntry::fullPath)
                     .collect(Collectors.joining(", "));
-            throw new IOException("Mehrere JAR-Dateien im Archiv gefunden. Bitte konfiguriere 'archiveEntryPattern'. Kandidaten: "
+            throw new IOException("Multiple JAR files found in the archive. Please configure 'archiveEntryPattern'. Candidates: "
                     + candidates);
         }
 

--- a/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/gui/PluginOverviewGui.java
@@ -84,11 +84,11 @@ public class PluginOverviewGui implements Listener {
 
     public void open(Player player) {
         if (!player.hasPermission(Permissions.GUI_OPEN)) {
-            player.sendMessage(ChatColor.RED + "Dir fehlt die Berechtigung, die NU2L-GUI zu öffnen.");
+            player.sendMessage(ChatColor.RED + "You do not have permission to open the NU2L GUI.");
             return;
         }
         if (context.getPluginLifecycleManager() == null) {
-            player.sendMessage(ChatColor.RED + "Die Plugin-Verwaltung ist deaktiviert.");
+            player.sendMessage(ChatColor.RED + "Plugin management is disabled.");
             return;
         }
         openOverview(player);
@@ -126,8 +126,8 @@ public class PluginOverviewGui implements Listener {
         player.openInventory(inventory);
 
         if (truncated) {
-            player.sendMessage(ChatColor.YELLOW + "Es werden nur die ersten " + availableSlots
-                    + " Plugins angezeigt (" + plugins.size() + " insgesamt).");
+            player.sendMessage(ChatColor.YELLOW + "Only the first " + availableSlots
+                    + " plugins are shown (" + plugins.size() + " total).");
         }
     }
 
@@ -169,28 +169,28 @@ public class PluginOverviewGui implements Listener {
                 if (version != null && !version.isBlank()) {
                     lore.add(ChatColor.GRAY + "Version: " + ChatColor.AQUA + version);
                 }
-                lore.add(ChatColor.GRAY + "Aktiviert: "
-                        + (loaded.isEnabled() ? ChatColor.GREEN + "Ja" : ChatColor.RED + "Nein"));
-            }, () -> lore.add(ChatColor.RED + "Nicht geladen"));
+                lore.add(ChatColor.GRAY + "Enabled: "
+                        + (loaded.isEnabled() ? ChatColor.GREEN + "Yes" : ChatColor.RED + "No"));
+            }, () -> lore.add(ChatColor.RED + "Not loaded"));
 
             Path path = plugin.getPath();
             if (path != null) {
-                lore.add(ChatColor.DARK_GRAY + "Datei: " + ChatColor.WHITE + path.getFileName());
+                lore.add(ChatColor.DARK_GRAY + "File: " + ChatColor.WHITE + path.getFileName());
                 findMatchingSource(plugin).ifPresentOrElse(source -> {
-                    lore.add(ChatColor.GRAY + "Update-Quelle: " + ChatColor.AQUA + source.getName());
-                    lore.add(ChatColor.YELLOW + "Klicke, um den Link zu aktualisieren.");
-            }, () -> lore.add(ChatColor.RED + "Keine Update-Quelle verknüpft – klicken, um Link zu setzen."));
+                    lore.add(ChatColor.GRAY + "Update source: " + ChatColor.AQUA + source.getName());
+                    lore.add(ChatColor.YELLOW + "Click to update the link.");
+            }, () -> lore.add(ChatColor.RED + "No update source linked – click to set one."));
         } else {
-            lore.add(ChatColor.RED + "Kein JAR-Pfad gefunden – Link nicht möglich.");
+            lore.add(ChatColor.RED + "No JAR path found – cannot link.");
         }
 
         PluginUpdateSettings settings = readSettings(plugin);
         if (!settings.autoUpdateEnabled()) {
-            lore.add(ChatColor.GRAY + "Updates: " + ChatColor.RED + "Automatisch deaktiviert");
+            lore.add(ChatColor.GRAY + "Updates: " + ChatColor.RED + "Automatic updates disabled");
         } else if (settings.behaviour() == UpdateBehaviour.AUTO_RELOAD) {
-            lore.add(ChatColor.GRAY + "Updates: " + ChatColor.GREEN + "Automatisch neu laden");
+            lore.add(ChatColor.GRAY + "Updates: " + ChatColor.GREEN + "Automatically reload");
         } else {
-            lore.add(ChatColor.GRAY + "Updates: " + ChatColor.GOLD + "Serverneustart erforderlich");
+            lore.add(ChatColor.GRAY + "Updates: " + ChatColor.GOLD + "Server restart required");
         }
 
         meta.setLore(lore);
@@ -201,12 +201,12 @@ public class PluginOverviewGui implements Listener {
 
     private String statusLabel(ManagedPlugin plugin) {
         if (plugin.isEnabled()) {
-            return ChatColor.GREEN + "Aktiv";
+            return ChatColor.GREEN + "Active";
         }
         if (plugin.isLoaded()) {
-            return ChatColor.YELLOW + "Geladen";
+            return ChatColor.YELLOW + "Loaded";
         }
-        return ChatColor.RED + "Nicht geladen";
+        return ChatColor.RED + "Not loaded";
     }
 
     private ItemStack createFiller() {
@@ -235,20 +235,20 @@ public class PluginOverviewGui implements Listener {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             if (!plugin.isLoaded()) {
-                meta.setDisplayName(ChatColor.DARK_GRAY + "Aktivieren (nicht möglich)");
+                meta.setDisplayName(ChatColor.DARK_GRAY + "Enable (not possible)");
                 meta.setLore(List.of(
-                        ChatColor.GRAY + "Das Plugin ist derzeit nicht geladen.",
-                        ChatColor.GRAY + "Lade es, um es zu aktivieren."
+                        ChatColor.GRAY + "The plugin is not currently loaded.",
+                        ChatColor.GRAY + "Load it to enable it."
                 ));
             } else if (plugin.isEnabled()) {
-                meta.setDisplayName(ChatColor.RED + "Plugin deaktivieren");
+                meta.setDisplayName(ChatColor.RED + "Disable plugin");
                 meta.setLore(List.of(
-                        ChatColor.GRAY + "Stoppt das Plugin, ohne es zu entladen."
+                        ChatColor.GRAY + "Stops the plugin without unloading it."
                 ));
             } else {
-                meta.setDisplayName(ChatColor.GREEN + "Plugin aktivieren");
+                meta.setDisplayName(ChatColor.GREEN + "Enable plugin");
                 meta.setLore(List.of(
-                        ChatColor.GRAY + "Startet das Plugin nach dem Laden."
+                        ChatColor.GRAY + "Starts the plugin after it has been loaded."
                 ));
             }
             item.setItemMeta(meta);
@@ -262,15 +262,15 @@ public class PluginOverviewGui implements Listener {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             if (loaded) {
-                meta.setDisplayName(ChatColor.GOLD + "Plugin entladen");
+                meta.setDisplayName(ChatColor.GOLD + "Unload plugin");
                 meta.setLore(List.of(
-                        ChatColor.GRAY + "Entlädt das Plugin vollständig.",
-                        ChatColor.GRAY + "Befreit Ressourcen und entfernt Listener."
+                        ChatColor.GRAY + "Fully unloads the plugin.",
+                        ChatColor.GRAY + "Frees resources and unregisters listeners."
                 ));
             } else {
-                meta.setDisplayName(ChatColor.AQUA + "Plugin laden");
+                meta.setDisplayName(ChatColor.AQUA + "Load plugin");
                 meta.setLore(List.of(
-                        ChatColor.GRAY + "Lädt das Plugin aus der JAR-Datei und aktiviert es."
+                        ChatColor.GRAY + "Loads the plugin from the JAR file and enables it."
                 ));
             }
             item.setItemMeta(meta);
@@ -282,10 +282,10 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.PAPER);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.AQUA + "Update-Link festlegen");
+            meta.setDisplayName(ChatColor.AQUA + "Set update link");
             meta.setLore(List.of(
-                    ChatColor.GRAY + "Klicke, um eine neue Download-URL einzugeben.",
-                    ChatColor.GRAY + "Eigene Links ermöglichen Installation und Updates."
+                    ChatColor.GRAY + "Click to enter a new download URL.",
+                    ChatColor.GRAY + "Custom links allow installation and updates."
             ));
             item.setItemMeta(meta);
         }
@@ -301,25 +301,25 @@ public class PluginOverviewGui implements Listener {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             if (source.isPresent()) {
-                meta.setDisplayName(ChatColor.RED + "Automatische Updates deaktivieren");
+                meta.setDisplayName(ChatColor.RED + "Disable automatic updates");
                 List<String> lore = new ArrayList<>();
-                lore.add(ChatColor.GRAY + "Entfernt die Update-Quelle aus NU2L.");
-                lore.add(ChatColor.GRAY + "Das Plugin bleibt installiert.");
+                lore.add(ChatColor.GRAY + "Removes the update source from NU2L.");
+                lore.add(ChatColor.GRAY + "The plugin remains installed.");
                 String sourceName = source.get().getName();
                 if (sourceName != null && !sourceName.isBlank()) {
-                    lore.add(ChatColor.DARK_GRAY + "Quelle: " + ChatColor.AQUA + sourceName);
+                    lore.add(ChatColor.DARK_GRAY + "Source: " + ChatColor.AQUA + sourceName);
                 }
-                lore.add(ChatColor.YELLOW + "Klicken, um Updates zu deaktivieren.");
+                lore.add(ChatColor.YELLOW + "Click to disable updates.");
                 meta.setLore(lore);
             } else {
-                meta.setDisplayName(ChatColor.GREEN + "Keine Update-Verknüpfung aktiv");
+                meta.setDisplayName(ChatColor.GREEN + "No update link active");
                 List<String> lore = new ArrayList<>();
                 if (!settings.autoUpdateEnabled()) {
-                    lore.add(ChatColor.GRAY + "Automatische Updates sind deaktiviert.");
+                    lore.add(ChatColor.GRAY + "Automatic updates are disabled.");
                 } else {
-                    lore.add(ChatColor.GRAY + "Dieses Plugin wird aktuell nicht automatisch aktualisiert.");
+                    lore.add(ChatColor.GRAY + "This plugin is not currently updating automatically.");
                 }
-                lore.add(ChatColor.GRAY + "Nutze \"Update-Link festlegen\", um Updates zu aktivieren.");
+                lore.add(ChatColor.GRAY + "Use \"Set update link\" to enable updates.");
                 meta.setLore(lore);
             }
             item.setItemMeta(meta);
@@ -332,23 +332,23 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.COMPARATOR);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.LIGHT_PURPLE + "Update-Verhalten anpassen");
+            meta.setDisplayName(ChatColor.LIGHT_PURPLE + "Adjust update behavior");
             String current;
             if (!settings.autoUpdateEnabled()) {
-                current = ChatColor.RED + "Automatische Updates deaktiviert";
+                current = ChatColor.RED + "Automatic updates disabled";
             } else if (settings.behaviour() == UpdateBehaviour.AUTO_RELOAD) {
-                current = ChatColor.GREEN + "Automatisch neu laden";
+                current = ChatColor.GREEN + "Automatically reload";
             } else {
-                current = ChatColor.GOLD + "Serverneustart nach Updates";
+                current = ChatColor.GOLD + "Restart server after updates";
             }
             meta.setLore(List.of(
-                    ChatColor.GRAY + "Aktueller Modus:",
+                    ChatColor.GRAY + "Current mode:",
                     ChatColor.GRAY + " → " + current,
-                    ChatColor.GRAY + "Dateiname: "
+                    ChatColor.GRAY + "File name: "
                             + (settings.retainUpstreamFilename()
                             ? ChatColor.GREEN + "Upstream"
-                            : ChatColor.YELLOW + "Konfiguriert"),
-                    ChatColor.YELLOW + "Links/Rechts Klick für Optionen"
+                            : ChatColor.YELLOW + "Configured"),
+                    ChatColor.YELLOW + "Left/Right click for options"
             ));
             item.setItemMeta(meta);
         }
@@ -359,10 +359,10 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.TNT);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.RED + "Plugin entfernen");
+            meta.setDisplayName(ChatColor.RED + "Remove plugin");
             meta.setLore(List.of(
-                    ChatColor.GRAY + "Entlädt das Plugin, löscht die Datei",
-                    ChatColor.GRAY + "und entfernt die Update-Quelle."
+                    ChatColor.GRAY + "Unloads the plugin, deletes the file",
+                    ChatColor.GRAY + "and removes the update source."
             ));
             item.setItemMeta(meta);
         }
@@ -373,10 +373,10 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.NAME_TAG);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.AQUA + "Datei umbenennen");
+            meta.setDisplayName(ChatColor.AQUA + "Rename file");
             meta.setLore(List.of(
-                    ChatColor.GRAY + "Ändert den Namen der JAR-Datei",
-                    ChatColor.GRAY + "und aktualisiert die Update-Quelle."
+                    ChatColor.GRAY + "Changes the JAR file name",
+                    ChatColor.GRAY + "and updates the linked source."
             ));
             item.setItemMeta(meta);
         }
@@ -412,12 +412,12 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.CHEST);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.GREEN + "Mit Datenordner angleichen");
+            meta.setDisplayName(ChatColor.GREEN + "Match data folder name");
             meta.setLore(List.of(
-                    ChatColor.GRAY + "Benennt die Datei automatisch um,",
-                    ChatColor.GRAY + "damit sie wie der Datenordner heißt.",
+                    ChatColor.GRAY + "Automatically renames the file,",
+                    ChatColor.GRAY + "so it matches the data folder name.",
                     " ",
-                    ChatColor.DARK_GRAY + "Ziel: " + ChatColor.AQUA + sanitized
+                    ChatColor.DARK_GRAY + "Target: " + ChatColor.AQUA + sanitized
             ));
             item.setItemMeta(meta);
         }
@@ -428,8 +428,8 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.ARROW);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.YELLOW + "Zurück zur Übersicht");
-            meta.setLore(List.of(ChatColor.GRAY + "Schließt diese Ansicht und zeigt alle Plugins."));
+            meta.setDisplayName(ChatColor.YELLOW + "Back to overview");
+            meta.setLore(List.of(ChatColor.GRAY + "Closes this view and shows all plugins."));
             item.setItemMeta(meta);
         }
         return item;
@@ -439,10 +439,10 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.NETHER_STAR);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.AQUA + "Neues Plugin installieren …");
+            meta.setDisplayName(ChatColor.AQUA + "Install new plugin…");
             meta.setLore(List.of(
-                    ChatColor.GRAY + "Klicke, um eine Download-URL einzugeben.",
-                    ChatColor.GRAY + "Die Installation läuft direkt über NU2L."
+                    ChatColor.GRAY + "Click to enter a download URL.",
+                    ChatColor.GRAY + "Installation runs directly through NU2L."
             ));
             item.setItemMeta(meta);
         }
@@ -455,38 +455,38 @@ public class PluginOverviewGui implements Listener {
         }
         PluginLifecycleManager manager = context.getPluginLifecycleManager();
         if (manager == null) {
-            player.sendMessage(ChatColor.RED + "Die Plugin-Verwaltung ist deaktiviert.");
+            player.sendMessage(ChatColor.RED + "Plugin management is disabled.");
             return;
         }
 
         String pluginName = plugin.getName();
         if (pluginName == null) {
-            player.sendMessage(ChatColor.RED + "Pluginname konnte nicht ermittelt werden.");
+            player.sendMessage(ChatColor.RED + "Could not determine plugin name.");
             return;
         }
 
         try {
             if (!plugin.isLoaded()) {
-                player.sendMessage(ChatColor.RED + "Bitte lade das Plugin, bevor du es aktivierst.");
+                player.sendMessage(ChatColor.RED + "Please load the plugin before enabling it.");
             } else if (plugin.isEnabled()) {
                 if (manager.disablePlugin(pluginName)) {
                     player.sendMessage(ChatColor.YELLOW + "Plugin " + ChatColor.AQUA + pluginName
-                            + ChatColor.YELLOW + " wurde deaktiviert.");
+                            + ChatColor.YELLOW + " has been disabled.");
                 } else {
-                    player.sendMessage(ChatColor.RED + "Plugin konnte nicht deaktiviert werden.");
+                    player.sendMessage(ChatColor.RED + "Could not disable plugin.");
                 }
             } else {
                 if (manager.enablePlugin(pluginName)) {
                     player.sendMessage(ChatColor.GREEN + "Plugin " + ChatColor.AQUA + pluginName
-                            + ChatColor.GREEN + " wurde aktiviert.");
+                            + ChatColor.GREEN + " has been enabled.");
                 } else {
-                    player.sendMessage(ChatColor.RED + "Plugin konnte nicht aktiviert werden.");
+                    player.sendMessage(ChatColor.RED + "Could not enable plugin.");
                 }
             }
         } catch (PluginLifecycleException ex) {
             context.getPlugin().getLogger().log(Level.WARNING,
                     "Failed to toggle plugin " + pluginName, ex);
-            player.sendMessage(ChatColor.RED + "Aktion fehlgeschlagen: " + ex.getMessage());
+            player.sendMessage(ChatColor.RED + "Action failed: " + ex.getMessage());
         }
 
         openPluginDetails(player, plugin);
@@ -498,13 +498,13 @@ public class PluginOverviewGui implements Listener {
         }
         PluginLifecycleManager manager = context.getPluginLifecycleManager();
         if (manager == null) {
-            player.sendMessage(ChatColor.RED + "Die Plugin-Verwaltung ist deaktiviert.");
+            player.sendMessage(ChatColor.RED + "Plugin management is disabled.");
             return;
         }
 
         String pluginName = plugin.getName();
         if (pluginName == null) {
-            player.sendMessage(ChatColor.RED + "Pluginname konnte nicht ermittelt werden.");
+            player.sendMessage(ChatColor.RED + "Could not determine plugin name.");
             return;
         }
 
@@ -512,27 +512,27 @@ public class PluginOverviewGui implements Listener {
             if (plugin.isLoaded()) {
                 if (manager.unloadPlugin(pluginName)) {
                     player.sendMessage(ChatColor.YELLOW + "Plugin " + ChatColor.AQUA + pluginName
-                            + ChatColor.YELLOW + " wurde entladen.");
+                            + ChatColor.YELLOW + " has been unloaded.");
                 } else {
-                    player.sendMessage(ChatColor.RED + "Plugin konnte nicht entladen werden.");
+                    player.sendMessage(ChatColor.RED + "Could not unload plugin.");
                 }
             } else {
                 Path path = plugin.getPath();
                 if (path == null) {
-                    player.sendMessage(ChatColor.RED + "Es ist kein JAR-Pfad für dieses Plugin bekannt.");
+                    player.sendMessage(ChatColor.RED + "No JAR path is known for this plugin.");
                     return;
                 }
                 if (manager.loadPlugin(path)) {
                     player.sendMessage(ChatColor.GREEN + "Plugin " + ChatColor.AQUA + pluginName
-                            + ChatColor.GREEN + " wurde geladen und aktiviert.");
+                            + ChatColor.GREEN + " has been loaded and enabled.");
                 } else {
-                    player.sendMessage(ChatColor.RED + "Plugin konnte nicht geladen werden.");
+                    player.sendMessage(ChatColor.RED + "Could not load plugin.");
                 }
             }
         } catch (PluginLifecycleException ex) {
             context.getPlugin().getLogger().log(Level.WARNING,
                     "Failed to toggle plugin load state for " + pluginName, ex);
-            player.sendMessage(ChatColor.RED + "Aktion fehlgeschlagen: " + ex.getMessage());
+            player.sendMessage(ChatColor.RED + "Action failed: " + ex.getMessage());
         }
 
         openPluginDetails(player, plugin);
@@ -547,13 +547,13 @@ public class PluginOverviewGui implements Listener {
             return;
         }
         if (updateSettingsRepository == null) {
-            player.sendMessage(ChatColor.RED + "Update-Einstellungen können derzeit nicht gespeichert werden.");
+            player.sendMessage(ChatColor.RED + "Update settings cannot be saved right now.");
             return;
         }
 
         String pluginName = plugin.getName();
         if (pluginName == null || pluginName.isBlank()) {
-            player.sendMessage(ChatColor.RED + "Pluginname konnte nicht ermittelt werden.");
+            player.sendMessage(ChatColor.RED + "Could not determine plugin name.");
             return;
         }
 
@@ -565,15 +565,15 @@ public class PluginOverviewGui implements Listener {
         if (!current.autoUpdateEnabled()) {
             next = new PluginUpdateSettings(true, UpdateBehaviour.AUTO_RELOAD, current.retainUpstreamFilename());
             color = ChatColor.GREEN;
-            message = "Automatische Updates aktiviert. Das Plugin wird nach Updates neu geladen.";
+            message = "Automatic updates enabled. The plugin will reload after updates.";
         } else if (current.behaviour() == UpdateBehaviour.AUTO_RELOAD) {
             next = new PluginUpdateSettings(true, UpdateBehaviour.REQUIRE_RESTART, current.retainUpstreamFilename());
             color = ChatColor.GOLD;
-            message = "Automatische Updates erfordern nun einen Serverneustart.";
+            message = "Automatic updates now require a server restart.";
         } else {
             next = new PluginUpdateSettings(false, UpdateBehaviour.REQUIRE_RESTART, current.retainUpstreamFilename());
             color = ChatColor.RED;
-            message = "Automatische Updates für dieses Plugin wurden deaktiviert.";
+            message = "Automatic updates for this plugin have been disabled.";
         }
 
         updateSettingsRepository.saveSettings(pluginName, next);
@@ -587,13 +587,13 @@ public class PluginOverviewGui implements Listener {
         }
 
         if (updateSettingsRepository == null) {
-            player.sendMessage(ChatColor.RED + "Update-Einstellungen können derzeit nicht gespeichert werden.");
+            player.sendMessage(ChatColor.RED + "Update settings cannot be saved right now.");
             return;
         }
 
         String pluginName = plugin.getName();
         if (pluginName == null || pluginName.isBlank()) {
-            player.sendMessage(ChatColor.RED + "Pluginname konnte nicht ermittelt werden.");
+            player.sendMessage(ChatColor.RED + "Could not determine plugin name.");
             return;
         }
 
@@ -603,9 +603,9 @@ public class PluginOverviewGui implements Listener {
                 new PluginUpdateSettings(current.autoUpdateEnabled(), current.behaviour(), retain));
 
         if (retain) {
-            player.sendMessage(ChatColor.GREEN + "Upstream-Dateinamen werden künftig beibehalten (alte Dateien werden gelöscht).");
+            player.sendMessage(ChatColor.GREEN + "Upstream file names will now be kept (old files will be deleted).");
         } else {
-            player.sendMessage(ChatColor.YELLOW + "NU2L verwendet wieder feste Dateinamen aus der Konfiguration.");
+            player.sendMessage(ChatColor.YELLOW + "NU2L will once again use configured file names.");
         }
 
         openPluginDetails(player, plugin);
@@ -618,7 +618,7 @@ public class PluginOverviewGui implements Listener {
         player.closeInventory();
         openInventories.remove(player.getUniqueId());
         pendingLinkRequests.put(player.getUniqueId(), new LinkRequest(null, true));
-        player.sendMessage(ChatColor.AQUA + "Bitte gib die Download-URL des neuen Plugins im Chat ein oder tippe 'abbrechen'.");
+        player.sendMessage(ChatColor.AQUA + "Please enter the download URL of the new plugin in chat or type 'cancel'.");
     }
 
     @EventHandler
@@ -776,25 +776,25 @@ public class PluginOverviewGui implements Listener {
         }
 
         if (message.isBlank()) {
-            player.sendMessage(ChatColor.RED + "Bitte gib einen gültigen Link ein oder tippe 'abbrechen'.");
+            player.sendMessage(ChatColor.RED + "Please enter a valid link or type 'cancel'.");
             return;
         }
 
         if (message.equalsIgnoreCase("abbrechen") || message.equalsIgnoreCase("cancel")) {
             pendingLinkRequests.remove(playerId);
-            player.sendMessage(ChatColor.YELLOW + "Verknüpfung abgebrochen.");
+            player.sendMessage(ChatColor.YELLOW + "Linking cancelled.");
             return;
         }
 
         pendingLinkRequests.remove(playerId);
         if (request.standalone()) {
-            player.sendMessage(ChatColor.GREEN + "Starte Installation eines neuen Plugins …");
+            player.sendMessage(ChatColor.GREEN + "Starting installation of a new plugin…");
             coordinator.install(player, message);
             return;
         }
 
         String pluginName = request.pluginName();
-        player.sendMessage(ChatColor.GREEN + "Verarbeite Link für " + ChatColor.AQUA + pluginName + ChatColor.GREEN + " …");
+        player.sendMessage(ChatColor.GREEN + "Processing link for " + ChatColor.AQUA + pluginName + ChatColor.GREEN + " …");
         coordinator.installForPlugin(player, pluginName, message);
     }
 
@@ -809,7 +809,7 @@ public class PluginOverviewGui implements Listener {
 
         Path path = plugin.getPath();
         if (path == null) {
-            player.sendMessage(ChatColor.RED + "Für dieses Plugin konnte kein JAR gefunden werden.");
+            player.sendMessage(ChatColor.RED + "Could not find a JAR for this plugin.");
             return;
         }
 
@@ -826,7 +826,7 @@ public class PluginOverviewGui implements Listener {
         }
 
         pendingSuggestionRequests.put(playerId, plugin);
-        player.sendMessage(ChatColor.GRAY + "Suche nach passenden Quellen …");
+        player.sendMessage(ChatColor.GRAY + "Searching for matching sources…");
 
         context.getScheduler().runTaskAsynchronously(context.getPlugin(), () -> {
             List<PluginLinkSuggestion> suggestions;
@@ -858,14 +858,14 @@ public class PluginOverviewGui implements Listener {
         }
 
         if (suggestions == null || suggestions.isEmpty()) {
-            player.sendMessage(ChatColor.YELLOW + "Keine passenden Quellen gefunden. Bitte gib den Link manuell ein.");
+            player.sendMessage(ChatColor.YELLOW + "No matching sources found. Please enter the link manually.");
             promptManualLinkInput(player, plugin, Optional.empty());
             return;
         }
 
-        player.sendMessage(ChatColor.GREEN + "Es wurden " + suggestions.size()
-                + " mögliche Update-Quellen gefunden.");
-        player.sendMessage(ChatColor.GRAY + "Wähle einen Vorschlag aus oder trage einen Link manuell ein.");
+        player.sendMessage(ChatColor.GREEN + "Found " + suggestions.size()
+                + " potential update sources.");
+        player.sendMessage(ChatColor.GRAY + "Choose a suggestion or enter a link manually.");
         openLinkSuggestions(player, plugin, suggestions);
     }
 
@@ -879,7 +879,7 @@ public class PluginOverviewGui implements Listener {
         size = Math.min(size, MAX_SIZE);
 
         Inventory inventory = Bukkit.createInventory(null, size,
-                ChatColor.DARK_PURPLE + pluginName + " – Update-Quellen");
+                ChatColor.DARK_PURPLE + pluginName + " – Update sources");
 
         ItemStack filler = createFiller();
         for (int i = 0; i < size; i++) {
@@ -908,8 +908,8 @@ public class PluginOverviewGui implements Listener {
         player.closeInventory();
         openInventories.remove(player.getUniqueId());
         pendingLinkRequests.remove(player.getUniqueId());
-        player.sendMessage(ChatColor.GREEN + "Übernehme Vorschlag " + ChatColor.AQUA
-                + suggestion.provider() + ChatColor.GREEN + " für " + ChatColor.AQUA + pluginName + ChatColor.GREEN + " …");
+        player.sendMessage(ChatColor.GREEN + "Applying suggestion " + ChatColor.AQUA
+                + suggestion.provider() + ChatColor.GREEN + " for " + ChatColor.AQUA + pluginName + ChatColor.GREEN + " …");
         coordinator.installForPlugin(player, pluginName, suggestion.url());
     }
 
@@ -922,11 +922,11 @@ public class PluginOverviewGui implements Listener {
                 plugin.getPath() != null ? plugin.getPath().getFileName().toString() : "Plugin");
         pendingLinkRequests.put(playerId, new LinkRequest(pluginName, false));
 
-        player.sendMessage(ChatColor.AQUA + "Update-Link für " + pluginName + " festlegen.");
+        player.sendMessage(ChatColor.AQUA + "Set update link for " + pluginName + ".");
         existingSource.ifPresentOrElse(source ->
-                        player.sendMessage(ChatColor.GRAY + "Aktuelle Quelle: " + ChatColor.AQUA + source.getName()),
-                () -> player.sendMessage(ChatColor.GRAY + "Aktuell ist keine Quelle verknüpft."));
-        player.sendMessage(ChatColor.YELLOW + "Bitte gib die Download-URL im Chat ein oder tippe 'abbrechen'.");
+                        player.sendMessage(ChatColor.GRAY + "Current source: " + ChatColor.AQUA + source.getName()),
+                () -> player.sendMessage(ChatColor.GRAY + "No source is currently linked."));
+        player.sendMessage(ChatColor.YELLOW + "Please enter the download URL in chat or type 'cancel'.");
     }
 
     private List<String> buildSearchTerms(ManagedPlugin plugin) {
@@ -979,7 +979,7 @@ public class PluginOverviewGui implements Listener {
             String title = Objects.requireNonNullElse(suggestion.title(), suggestion.provider());
             meta.setDisplayName(ChatColor.AQUA + title + ChatColor.DARK_GRAY + " (" + suggestion.provider() + ")");
             List<String> lore = new ArrayList<>();
-            lore.add(ChatColor.GRAY + suggestion.provider() + " Vorschlag");
+            lore.add(ChatColor.GRAY + suggestion.provider() + " suggestion");
             for (String line : wrapText(suggestion.description(), 40)) {
                 lore.add(ChatColor.DARK_GRAY + line);
             }
@@ -991,7 +991,7 @@ public class PluginOverviewGui implements Listener {
             }
             lore.add(" ");
             lore.add(ChatColor.DARK_GRAY + suggestion.url());
-            lore.add(ChatColor.GREEN + "Klicken, um diesen Link zu übernehmen.");
+            lore.add(ChatColor.GREEN + "Click to use this link.");
             meta.setLore(lore);
             item.setItemMeta(meta);
         }
@@ -1002,10 +1002,10 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.OAK_SIGN);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.AQUA + "Link manuell eintragen");
+            meta.setDisplayName(ChatColor.AQUA + "Enter link manually");
             meta.setLore(List.of(
-                    ChatColor.GRAY + "Öffnet die Chat-Eingabe,",
-                    ChatColor.GRAY + "um eine URL selbst einzutragen."
+                    ChatColor.GRAY + "Opens chat input,",
+                    ChatColor.GRAY + "so you can enter a URL manually."
             ));
             item.setItemMeta(meta);
         }
@@ -1016,8 +1016,8 @@ public class PluginOverviewGui implements Listener {
         ItemStack item = new ItemStack(Material.ARROW);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.YELLOW + "Zurück zu den Plugin-Details");
-            meta.setLore(List.of(ChatColor.GRAY + "Kehrt zu den Details des Plugins zurück."));
+            meta.setDisplayName(ChatColor.YELLOW + "Back to plugin details");
+            meta.setLore(List.of(ChatColor.GRAY + "Returns to the plugin details."));
             item.setItemMeta(meta);
         }
         return item;
@@ -1055,9 +1055,9 @@ public class PluginOverviewGui implements Listener {
         }
         pendingRemovalRequests.put(player.getUniqueId(), plugin);
         player.closeInventory();
-        player.sendMessage(ChatColor.RED + "Bist du sicher, dass du "
-                + ChatColor.AQUA + plugin.getName() + ChatColor.RED + " entfernen möchtest?");
-        player.sendMessage(ChatColor.YELLOW + "Tippe \"ja\" zum Bestätigen oder \"abbrechen\" zum Abbrechen.");
+        player.sendMessage(ChatColor.RED + "Are you sure you want to remove "
+                + ChatColor.AQUA + plugin.getName() + ChatColor.RED + "?");
+        player.sendMessage(ChatColor.YELLOW + "Type \"yes\" to confirm or \"cancel\" to abort.");
     }
 
     private void handleRemovalInput(Player player, ManagedPlugin plugin, String message) {
@@ -1067,7 +1067,7 @@ public class PluginOverviewGui implements Listener {
         if (trimmed.equalsIgnoreCase("ja") || trimmed.equalsIgnoreCase("yes")) {
             coordinator.removeManagedPlugin(player, plugin);
         } else {
-            player.sendMessage(ChatColor.YELLOW + "Entfernen abgebrochen.");
+            player.sendMessage(ChatColor.YELLOW + "Removal cancelled.");
         }
     }
 
@@ -1085,7 +1085,7 @@ public class PluginOverviewGui implements Listener {
         }
         Path path = plugin.getPath();
         if (path == null) {
-            player.sendMessage(ChatColor.RED + "Für dieses Plugin konnte kein Dateipfad ermittelt werden.");
+            player.sendMessage(ChatColor.RED + "Could not determine a file path for this plugin.");
             return;
         }
 
@@ -1098,23 +1098,23 @@ public class PluginOverviewGui implements Listener {
         }
 
         anvilTextPrompt.open(player, AnvilTextPrompt.Prompt.builder()
-                .title(ChatColor.DARK_PURPLE + "NU2L Umbenennen")
+                .title(ChatColor.DARK_PURPLE + "NU2L Rename")
                 .initialText(currentName)
                 .inputItem(paper)
                 .previewFactory(this::createRenamePreview)
                 .validation(value -> {
                     if (value == null || value.trim().isEmpty()) {
-                        return Optional.of(ChatColor.RED + "Bitte gib einen gültigen Namen ein.");
+                        return Optional.of(ChatColor.RED + "Please enter a valid name.");
                     }
                     return Optional.empty();
                 })
                 .onConfirm((p, value) -> {
                     requestRename(p, plugin, value);
                 })
-                .onCancel(p -> p.sendMessage(ChatColor.YELLOW + "Umbenennen abgebrochen."))
+                .onCancel(p -> p.sendMessage(ChatColor.YELLOW + "Rename cancelled."))
                 .build());
 
-        player.sendMessage(ChatColor.GRAY + "Gib einen neuen Dateinamen ein (\".jar\" wird automatisch ergänzt).");
+        player.sendMessage(ChatColor.GRAY + "Enter a new file name (\".jar\" will be added automatically).");
     }
 
     private void requestRename(Player player, ManagedPlugin plugin, String requestedName) {
@@ -1135,31 +1135,31 @@ public class PluginOverviewGui implements Listener {
 
         Path path = plugin.getPath();
         if (path == null) {
-            player.sendMessage(ChatColor.RED + "Für dieses Plugin konnte kein Dateipfad ermittelt werden.");
+            player.sendMessage(ChatColor.RED + "Could not determine a file path for this plugin.");
             return;
         }
 
         Optional<Plugin> loadedPlugin = plugin.getPlugin();
         if (loadedPlugin.isEmpty()) {
-            player.sendMessage(ChatColor.RED + "Das Plugin muss geladen sein, um den Datenordnernamen zu ermitteln.");
+            player.sendMessage(ChatColor.RED + "The plugin must be loaded to determine the data folder name.");
             return;
         }
 
         File dataFolder = loadedPlugin.get().getDataFolder();
         if (dataFolder == null) {
-            player.sendMessage(ChatColor.RED + "Es konnte kein Datenordner für dieses Plugin gefunden werden.");
+            player.sendMessage(ChatColor.RED + "Could not find a data folder for this plugin.");
             return;
         }
 
         String sanitized = FileNameSanitizer.sanitizeJarFilename(dataFolder.getName());
         if (sanitized == null) {
-            player.sendMessage(ChatColor.RED + "Der Datenordnername ist ungültig.");
+            player.sendMessage(ChatColor.RED + "The data folder name is invalid.");
             return;
         }
 
         String current = path.getFileName().toString();
         if (sanitized.equals(current)) {
-            player.sendMessage(ChatColor.GRAY + "Die Datei heißt bereits wie der Datenordner.");
+            player.sendMessage(ChatColor.GRAY + "The file is already named after the data folder.");
             return;
         }
 

--- a/src/main/java/eu/nurkert/neverUp2Late/gui/anvil/AnvilTextPrompt.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/gui/anvil/AnvilTextPrompt.java
@@ -180,13 +180,13 @@ public class AnvilTextPrompt implements Listener {
 
     public static final class Builder {
 
-        private String title = ChatColor.DARK_PURPLE + "Eingabe";
+        private String title = ChatColor.DARK_PURPLE + "Input";
         private String initialText = "";
         private ItemStack inputItem = new ItemStack(Material.PAPER);
         private Function<String, ItemStack> previewFactory;
         private Function<String, Optional<String>> validation = value -> {
             if (value == null || value.isBlank()) {
-                return Optional.of(ChatColor.RED + "Bitte gib einen Wert ein.");
+                return Optional.of(ChatColor.RED + "Please enter a value.");
             }
             return Optional.empty();
         };

--- a/src/main/java/eu/nurkert/neverUp2Late/handlers/UpdateHandler.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/handlers/UpdateHandler.java
@@ -171,7 +171,7 @@ public class UpdateHandler {
     public void runJobNow(UpdateSource source, CommandSender sender) {
         Objects.requireNonNull(source, "source");
         if (shuttingDown || !plugin.isEnabled()) {
-            notify(sender, ChatColor.RED + "Der Updater wird gerade deaktiviert. Bitte versuche es später erneut.");
+            notify(sender, ChatColor.RED + "The updater is currently shutting down. Please try again later.");
             return;
         }
         scheduler.runTaskAsynchronously(plugin, () -> executeManualRun(source, sender));
@@ -179,7 +179,7 @@ public class UpdateHandler {
 
     private void executeManualRun(UpdateSource source, CommandSender sender) {
         if (shuttingDown || !plugin.isEnabled()) {
-            notify(sender, ChatColor.RED + "Der Updater wird gerade deaktiviert. Bitte versuche es später erneut.");
+            notify(sender, ChatColor.RED + "The updater is currently shutting down. Please try again later.");
             return;
         }
         File pluginsFolder = plugin.getDataFolder().getParentFile();
@@ -189,13 +189,13 @@ public class UpdateHandler {
         UpdateContext context = new UpdateContext(source, destination, logger);
         configureRetention(context, destination);
 
-        notify(sender, ChatColor.YELLOW + "Prüfe " + displayName(source) + " auf neue Versionen …");
+        notify(sender, ChatColor.YELLOW + "Checking " + displayName(source) + " for new versions…");
 
         try {
             job.run(context);
             handleFilenameRetention(context);
             if (context.isCancelled()) {
-                String reason = context.getCancelReason().orElse("Installation abgebrochen.");
+                String reason = context.getCancelReason().orElse("Installation cancelled.");
                 notify(sender, ChatColor.GOLD + reason);
                 return;
             }
@@ -203,17 +203,17 @@ public class UpdateHandler {
             String version = context.getLatestVersion();
             String buildInfo = version != null ? "Version " + version : "Build " + context.getLatestBuild();
             String destinationFile = destination.getFileName() != null ? destination.getFileName().toString() : destination.toString();
-            notify(sender, ChatColor.GREEN + "Installation abgeschlossen: " + displayName(source) + " "
-                    + buildInfo + " → " + destinationFile + ". Bitte Server neu starten.");
+            notify(sender, ChatColor.GREEN + "Installation complete: " + displayName(source) + " "
+                    + buildInfo + " → " + destinationFile + ". Please restart the server.");
         } catch (UnknownHostException e) {
-            notify(sender, ChatColor.RED + "Download fehlgeschlagen: " + e.getMessage());
+            notify(sender, ChatColor.RED + "Download failed: " + e.getMessage());
             handleUnknownHost(source, e);
         } catch (IOException e) {
-            notify(sender, ChatColor.RED + "I/O-Fehler: " + e.getMessage());
+            notify(sender, ChatColor.RED + "I/O error: " + e.getMessage());
             logger.log(Level.WARNING,
                     "I/O error while installing {0}: {1}", new Object[]{source.getName(), e.getMessage()});
         } catch (Exception e) {
-            notify(sender, ChatColor.RED + "Unerwarteter Fehler: " + e.getMessage());
+            notify(sender, ChatColor.RED + "Unexpected error: " + e.getMessage());
             logger.log(Level.SEVERE, "Unexpected error while running manual update for " + source.getName(), e);
         }
     }
@@ -227,7 +227,7 @@ public class UpdateHandler {
 
     private String displayName(UpdateSource source) {
         String name = source.getName();
-        return name == null ? "Unbekannte Quelle" : name;
+        return name == null ? "Unknown source" : name;
     }
 
     private boolean shouldSkipAutomaticUpdate(UpdateSource source, Path destination) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,18 +5,18 @@ author: nurkert
 api-version: '1.21'
 commands:
   nu2l:
-    description: Installiert Plugins direkt aus einer URL.
+    description: Installs plugins directly from a URL.
     usage: "/<command> <url>"
     permission: neverup2late.install
 permissions:
   neverup2late.install:
-    description: Erlaubt die Nutzung des /nu2l Kommandos zum Installieren neuer Update-Quellen.
+    description: Allows using the /nu2l command to install new update sources.
     default: op
   neverup2late.gui.open:
-    description: Erlaubt das Öffnen der grafischen Oberfläche.
+    description: Allows opening the graphical interface.
     default: op
   neverup2late.gui.manage:
-    description: Bündelt alle Verwaltungsrechte in der GUI.
+    description: Grants all management permissions in the GUI.
     default: op
     children:
       neverup2late.gui.manage.lifecycle: true
@@ -25,17 +25,17 @@ permissions:
       neverup2late.gui.manage.rename: true
       neverup2late.gui.manage.remove: true
   neverup2late.gui.manage.lifecycle:
-    description: Erlaubt Plugins über die GUI zu laden, zu entladen und zu aktivieren.
+    description: Allows loading, unloading, and enabling plugins through the GUI.
     default: op
   neverup2late.gui.manage.link:
-    description: Erlaubt das Verknüpfen von Plugins mit Update-Quellen.
+    description: Allows linking plugins with update sources.
     default: op
   neverup2late.gui.manage.settings:
-    description: Erlaubt das Anpassen der Update-Einstellungen in der GUI.
+    description: Allows adjusting update settings in the GUI.
     default: op
   neverup2late.gui.manage.rename:
-    description: Erlaubt das Umbenennen von Plugin-Dateien über die GUI.
+    description: Allows renaming plugin files through the GUI.
     default: op
   neverup2late.gui.manage.remove:
-    description: Erlaubt das Entfernen von Plugins über die GUI.
+    description: Allows removing plugins through the GUI.
     default: op


### PR DESCRIPTION
## Summary
- translate all GUI prompts, command feedback, and updater messages to English for player-facing interactions
- update quick installer logging and archive handling errors to English and improve clarity of status messages
- convert plugin metadata descriptions and default prompts to English for consistency

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68ded4d71a3083228e2c16a14a019208