### PR TITLE
Avoid reloading plugins immediately after rename

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -1001,7 +1001,6 @@ public class QuickInstallCoordinator {
                 return;
             }
 
-            boolean wasEnabled = target.isEnabled();
             boolean wasLoaded = target.isLoaded();
             String pluginName = Optional.ofNullable(target.getName()).orElse("Plugin");
 
@@ -1051,20 +1050,10 @@ public class QuickInstallCoordinator {
 
             pluginLifecycleManager.updateManagedPluginPath(currentPath, targetPath);
 
-            if (wasLoaded) {
-                try {
-                    pluginLifecycleManager.loadPlugin(targetPath);
-                    if (wasEnabled) {
-                        pluginLifecycleManager.enablePlugin(pluginName);
-                    }
-                } catch (PluginLifecycleException ex) {
-                    send(sender, ChatColor.YELLOW + "Plugin was renamed but could not be reloaded: " + ex.getMessage());
-                    logger.log(Level.WARNING, "Failed to reload plugin after rename", ex);
-                    return;
-                }
-            }
-
             send(sender, ChatColor.GREEN + "Renamed plugin file to " + ChatColor.AQUA + sanitized + ChatColor.GREEN + ".");
+            if (wasLoaded) {
+                send(sender, ChatColor.YELLOW + "Please reload or restart the server to activate the plugin again.");
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- stop attempting to reload a plugin immediately after its jar is renamed to avoid duplicate identifier failures on Paper
- notify the user that a manual reload or restart is required when the plugin had been loaded before the rename

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68ded7f4d2d48322a53196015da43c9d