### PR TITLE
Fix anvil prompt creation for Paper 1.21

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/gui/anvil/AnvilTextPrompt.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/gui/anvil/AnvilTextPrompt.java
@@ -56,7 +56,7 @@ public class AnvilTextPrompt implements Listener {
             existing.cancel(player);
         }
 
-        Inventory inventory = Bukkit.createInventory(player, InventoryType.ANVIL, prompt.title());
+        Inventory inventory = Bukkit.createInventory(null, InventoryType.ANVIL, prompt.title());
         if (!(inventory instanceof AnvilInventory anvilInventory)) {
             throw new IllegalStateException("Failed to create anvil inventory");
         }


### PR DESCRIPTION
## Summary
- create anvil prompts using a neutral inventory holder so Paper can construct an AnvilInventory

## Testing
- mvn -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68dedefdcf2c8322b71398cf5adcd80e