### PR TITLE
Allow console setup completion and document skip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ an inventory interface that walks through:
 3. Confirming whether to restart immediately or later.
 
 When the wizard finishes, NeverUp2Late records the completion status and starts the scheduled update loop. You can reopen the
-wizard at any time with `/nu2l setup` while setup mode is active.
+wizard at any time with `/nu2l setup` while setup mode is active. Server operators can now complete the onboarding headlessly via
+`/nu2l setup complete` from the console, or apply a prepared configuration file with `/nu2l setup apply <file>`.
+
+To skip the wizard entirely on fresh installations, set `setup.skipWizard: true` in `config.yml`. The plugin will immediately
+persist the default sources and start update checks.
 
 ![Setup wizard showing update source selection](images/setup-update-source.png)
 
@@ -61,6 +65,8 @@ wizard at any time with `/nu2l setup` while setup mode is active.
 | `/nu2l select <number>` | Chooses an asset when multiple files are available. | `neverup2late.install` | Responds to prompts generated during quick install. |
 | `/nu2l remove <name>` | Unregisters an update source and stops managing its file. | `neverup2late.gui.manage.remove` | Available from console and players. |
 | `/nu2l setup` | Opens the first-run setup wizard. | `neverup2late.setup` | Players only; shows if setup is not completed. |
+| `/nu2l setup complete` | Stores default sources and marks setup as finished without opening the GUI. | `neverup2late.setup` | Works from console or in-game. |
+| `/nu2l setup apply <file>` | Loads update sources from a YAML file and finalises setup. | `neverup2late.setup` | File paths are resolved relative to the plugin folder (`setup-presets/<file>.yml` is also checked). |
 
 ### Permission Overview
 
@@ -117,6 +123,9 @@ reloading plugins.
 All configuration lives in `plugins/NeverUp2Late/config.yml`. The default layout looks like this:
 
 ```yaml
+setup:
+  skipWizard: false
+
 filenames:
   geyser: "Geyser-Spigot.jar"
   paper: "paper.jar"
@@ -140,6 +149,7 @@ updates:
 
 Key options:
 
+- `setup.skipWizard` – When `true`, NeverUp2Late skips the interactive wizard and applies default sources on startup.
 - `updateInterval` – Minutes between scheduled update checks.
 - `pluginLifecycle.autoManage` – Enables automatic plugin reloads and lifecycle controls. Set to `false` to keep manual restarts.
 - `filenames.<name>` – Default filename for a source if `updates.sources[].filename` is omitted.

--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -89,8 +89,12 @@ public final class NeverUp2Late extends JavaPlugin {
 
         AnvilTextPrompt anvilTextPrompt = new AnvilTextPrompt(this);
         setupManager = new InitialSetupManager(context, setupStateRepository, anvilTextPrompt);
-        if (setupStateRepository.getPhase() == SetupPhase.COMPLETED) {
+        boolean skipWizard = configuration.getBoolean("setup.skipWizard", false);
+        SetupPhase currentPhase = setupStateRepository.getPhase();
+        if (currentPhase == SetupPhase.COMPLETED) {
             updateHandler.start();
+        } else if (skipWizard) {
+            setupManager.completeSetup(getServer().getConsoleSender());
         } else {
             setupManager.enableSetupMode();
             getLogger().info("NeverUp2Late wartet auf die erste Einrichtung. Spieler mit neverup2late.setup erhalten automatisch eine Anleitung.");

--- a/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
@@ -61,15 +61,44 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length > 0 && "setup".equalsIgnoreCase(args[0])) {
-            if (!(sender instanceof Player player)) {
-                sender.sendMessage(ChatColor.RED + "The setup wizard can only be opened by players.");
-                return true;
-            }
             if (setupManager == null) {
-                sender.sendMessage(ChatColor.RED + "The setup wizard is not available.");
+                sender.sendMessage(ChatColor.RED + "The setup utilities are not available.");
                 return true;
             }
-            setupManager.openWizard(player);
+            if (!sender.hasPermission(Permissions.SETUP)) {
+                sender.sendMessage(ChatColor.RED + "You do not have permission to manage the setup wizard.");
+                return true;
+            }
+
+            if (args.length == 1) {
+                if (sender instanceof Player player) {
+                    setupManager.openWizard(player);
+                } else {
+                    sender.sendMessage(ChatColor.YELLOW + "Run /" + label + " setup complete to finish the wizard from the console.");
+                }
+                return true;
+            }
+
+            String subCommand = args[1];
+            if ("complete".equalsIgnoreCase(subCommand)) {
+                setupManager.completeSetup(sender);
+                return true;
+            }
+            if ("apply".equalsIgnoreCase(subCommand)) {
+                if (args.length < 3) {
+                    sender.sendMessage(ChatColor.RED + "Please provide the path or identifier of the configuration file to apply.");
+                    return true;
+                }
+                String configIdentifier = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
+                setupManager.applyConfiguration(sender, configIdentifier.trim());
+                return true;
+            }
+
+            if (sender instanceof Player player) {
+                setupManager.openWizard(player);
+            } else {
+                sender.sendMessage(ChatColor.RED + "Unknown setup sub-command: " + subCommand);
+            }
             return true;
         }
 
@@ -132,6 +161,12 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
         }
         if (args.length == 2 && "select".equalsIgnoreCase(args[0])) {
             return Collections.singletonList("<number>");
+        }
+        if (args.length == 2 && "setup".equalsIgnoreCase(args[0])) {
+            return List.of("complete", "apply");
+        }
+        if (args.length == 3 && "setup".equalsIgnoreCase(args[0]) && "apply".equalsIgnoreCase(args[1])) {
+            return Collections.singletonList("<file>");
         }
         return Collections.emptyList();
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,9 @@
+# Control the behaviour of the first-run setup wizard
+setup:
+  # When true, NeverUp2Late skips the interactive wizard and applies the default
+  # update sources immediately during server start.
+  skipWizard: false
+
 # The names of the jars as they are in the server directory
 filenames:
   geyser: "Geyser-Spigot.jar"


### PR DESCRIPTION
## Summary
- add `/nu2l setup complete` and `/nu2l setup apply <file>` subcommands so the wizard can be finished from the console
- extend the setup manager with programmatic completion and preset loading helpers, and start updates automatically when skipping the wizard
- introduce a `setup.skipWizard` configuration flag and document the new commands and option in the README

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dfc57370348322bbda8ced1ae7148d