### PR TITLE
Add backup management and rollback command

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -24,6 +24,8 @@ import eu.nurkert.neverUp2Late.persistence.UpdateStateRepository;
 import eu.nurkert.neverUp2Late.persistence.SetupStateRepository.SetupPhase;
 import eu.nurkert.neverUp2Late.setup.InitialSetupManager;
 
+import java.nio.file.Path;
+
 public final class NeverUp2Late extends JavaPlugin {
 
     private PluginContext context;
@@ -58,7 +60,9 @@ public final class NeverUp2Late extends JavaPlugin {
 
         InstallationHandler installationHandler = new InstallationHandler(this, pluginLifecycleManager, updateSettingsRepository);
         UpdateSourceRegistry updateSourceRegistry = new UpdateSourceRegistry(getLogger(), configuration);
-        ArtifactDownloader artifactDownloader = new ArtifactDownloader();
+        int maxBackups = Math.max(0, configuration.getInt("backups.maxCount", 5));
+        Path backupsDirectory = getDataFolder().toPath().resolve("backups");
+        ArtifactDownloader artifactDownloader = new ArtifactDownloader(backupsDirectory, maxBackups);
         VersionComparator versionComparator = new VersionComparator();
 
         UpdateHandler updateHandler = new UpdateHandler(
@@ -84,7 +88,8 @@ public final class NeverUp2Late extends JavaPlugin {
                 updateSourceRegistry,
                 pluginLifecycleManager,
                 updateSettingsRepository,
-                setupStateRepository
+                setupStateRepository,
+                artifactDownloader
         );
 
         AnvilTextPrompt anvilTextPrompt = new AnvilTextPrompt(this);

--- a/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
@@ -116,6 +116,24 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
+        if (args.length > 0 && "rollback".equalsIgnoreCase(args[0])) {
+            if (!sender.hasPermission(Permissions.INSTALL)) {
+                sender.sendMessage(ChatColor.RED + "You do not have permission to manage installations.");
+                return true;
+            }
+            if (args.length < 2) {
+                sender.sendMessage(ChatColor.RED + "Please provide the update source name to roll back.");
+                return true;
+            }
+            String pluginName = String.join(" ", Arrays.copyOfRange(args, 1, args.length)).trim();
+            if (pluginName.isEmpty()) {
+                sender.sendMessage(ChatColor.RED + "Please provide the update source name to roll back.");
+                return true;
+            }
+            coordinator.rollback(sender, pluginName);
+            return true;
+        }
+
         if (!sender.hasPermission(Permissions.INSTALL)) {
             sender.sendMessage(ChatColor.RED + "You do not have permission to manage installations.");
             return true;
@@ -157,7 +175,7 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            return List.of("gui", "select", "remove", "setup");
+            return List.of("gui", "select", "remove", "setup", "rollback");
         }
         if (args.length == 2 && "select".equalsIgnoreCase(args[0])) {
             return Collections.singletonList("<number>");
@@ -167,6 +185,9 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
         }
         if (args.length == 3 && "setup".equalsIgnoreCase(args[0]) && "apply".equalsIgnoreCase(args[1])) {
             return Collections.singletonList("<file>");
+        }
+        if (args.length == 2 && "rollback".equalsIgnoreCase(args[0])) {
+            return coordinator.getRollbackSuggestions();
         }
         return Collections.emptyList();
     }

--- a/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
@@ -1,5 +1,6 @@
 package eu.nurkert.neverUp2Late.core;
 
+import eu.nurkert.neverUp2Late.handlers.ArtifactDownloader;
 import eu.nurkert.neverUp2Late.handlers.InstallationHandler;
 import eu.nurkert.neverUp2Late.handlers.PersistentPluginHandler;
 import eu.nurkert.neverUp2Late.handlers.UpdateHandler;
@@ -26,6 +27,7 @@ public class PluginContext {
     private final PluginLifecycleManager pluginLifecycleManager;
     private final PluginUpdateSettingsRepository pluginUpdateSettingsRepository;
     private final SetupStateRepository setupStateRepository;
+    private final ArtifactDownloader artifactDownloader;
 
     public PluginContext(JavaPlugin plugin,
                          BukkitScheduler scheduler,
@@ -36,7 +38,8 @@ public class PluginContext {
                          eu.nurkert.neverUp2Late.update.UpdateSourceRegistry updateSourceRegistry,
                          PluginLifecycleManager pluginLifecycleManager,
                          PluginUpdateSettingsRepository pluginUpdateSettingsRepository,
-                         SetupStateRepository setupStateRepository) {
+                         SetupStateRepository setupStateRepository,
+                         ArtifactDownloader artifactDownloader) {
         this.plugin = plugin;
         this.scheduler = scheduler;
         this.configuration = configuration;
@@ -47,6 +50,7 @@ public class PluginContext {
         this.pluginLifecycleManager = pluginLifecycleManager;
         this.pluginUpdateSettingsRepository = pluginUpdateSettingsRepository;
         this.setupStateRepository = setupStateRepository;
+        this.artifactDownloader = artifactDownloader;
     }
 
     public JavaPlugin getPlugin() {
@@ -87,5 +91,9 @@ public class PluginContext {
 
     public SetupStateRepository getSetupStateRepository() {
         return setupStateRepository;
+    }
+
+    public ArtifactDownloader getArtifactDownloader() {
+        return artifactDownloader;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,6 +19,11 @@ pluginLifecycle:
   # The default is now true so the GUI is usable without manual configuration.
   autoManage: true
 
+# Configure how many backups NeverUp2Late keeps per update source before pruning
+# the oldest entries. Set to 0 to keep all backups.
+backups:
+  maxCount: 5
+
 # Ignore unstable builds (legacy location, still respected if updates.ignoreUnstable is absent)
 ignoreUnstable: true
 


### PR DESCRIPTION
## Summary
- create timestamped backups before downloading updates and prune according to configuration
- expose a /nu2l rollback command that restores the latest backup and reloads plugins when possible
- wire backup settings through the plugin context and configuration

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dfc7edb85c832282c3b7d3011a4fee