### PR TITLE
Add nu2l status subcommand and expose update source overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ persist the default sources and start update checks.
 |---------|-------------|------------|-------|
 | `/nu2l` | Opens the plugin overview GUI. | `neverup2late.gui.open` | Requires a player; shows managed plugins and install actions. |
 | `/nu2l gui` | Explicitly opens the GUI. | `neverup2late.gui.open` | Alias for `/nu2l`. |
+| `/nu2l status` | Lists configured update sources with their target path, stored build/version, and auto-update flag. | `neverup2late.install` | Works for players and console; read-only overview. |
 | `/nu2l <url>` | Runs quick installation for the provided URL. | `neverup2late.install` | Works from console or in-game; URLs must use HTTP(S). |
 | `/nu2l select <number>` | Chooses an asset when multiple files are available. | `neverup2late.install` | Responds to prompts generated during quick install. |
 | `/nu2l remove <name>` | Unregisters an update source and stops managing its file. | `neverup2late.gui.manage.remove` | Available from console and players. |
@@ -72,7 +73,7 @@ persist the default sources and start update checks.
 
 ```
 neverup2late.setup             # Access to the setup wizard
-neverup2late.install           # Use /nu2l <url> and manage quick installs
+neverup2late.install           # Use /nu2l <url>, /nu2l status, and manage quick installs
 neverup2late.gui.open          # Open the GUI
 neverup2late.gui.manage        # Grant all GUI management permissions
 neverup2late.gui.manage.lifecycle
@@ -83,6 +84,16 @@ neverup2late.gui.manage.remove
 ```
 
 Default operators receive all permissions listed above.
+
+#### Example `/nu2l status` output
+
+```
+Update source status:
+• paper → /home/mcserver/paper.jar | Version 1.21.1 (Build 123) | Auto-Update: enabled | Plugin: Paper
+• geyser → /home/mcserver/plugins/Geyser-Spigot.jar | No installation recorded | Auto-Update: disabled | Plugin: unassigned
+```
+
+The command prints colour-coded lines in-game and plain text in the console, so administrators can quickly verify what NeverUp2Late is managing without opening the GUI.
 
 ## Quick Install Workflow
 

--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -108,7 +108,7 @@ public final class NeverUp2Late extends JavaPlugin {
 
         QuickInstallCoordinator coordinator = new QuickInstallCoordinator(context);
         PluginOverviewGui overviewGui = new PluginOverviewGui(context, coordinator, anvilTextPrompt);
-        NeverUp2LateCommand command = new NeverUp2LateCommand(coordinator, overviewGui, setupManager);
+        NeverUp2LateCommand command = new NeverUp2LateCommand(coordinator, overviewGui, setupManager, context);
         PluginCommand pluginCommand = getCommand("nu2l");
         if (pluginCommand != null) {
             pluginCommand.setExecutor(command);

--- a/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/core/PluginContext.java
@@ -4,12 +4,26 @@ import eu.nurkert.neverUp2Late.handlers.ArtifactDownloader;
 import eu.nurkert.neverUp2Late.handlers.InstallationHandler;
 import eu.nurkert.neverUp2Late.handlers.PersistentPluginHandler;
 import eu.nurkert.neverUp2Late.handlers.UpdateHandler;
-import eu.nurkert.neverUp2Late.plugin.PluginLifecycleManager;
 import eu.nurkert.neverUp2Late.persistence.PluginUpdateSettingsRepository;
+import eu.nurkert.neverUp2Late.persistence.PluginUpdateSettingsRepository.PluginUpdateSettings;
 import eu.nurkert.neverUp2Late.persistence.SetupStateRepository;
+import eu.nurkert.neverUp2Late.persistence.UpdateStateRepository.PluginState;
+import eu.nurkert.neverUp2Late.plugin.ManagedPlugin;
+import eu.nurkert.neverUp2Late.plugin.PluginLifecycleManager;
+import eu.nurkert.neverUp2Late.update.UpdateSourceRegistry;
+import eu.nurkert.neverUp2Late.update.UpdateSourceRegistry.TargetDirectory;
+import eu.nurkert.neverUp2Late.update.UpdateSourceRegistry.UpdateSource;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Central registry for plugin level services and shared Bukkit infrastructure components.
@@ -23,7 +37,7 @@ public class PluginContext {
     private final PersistentPluginHandler persistentPluginHandler;
     private final UpdateHandler updateHandler;
     private final InstallationHandler installationHandler;
-    private final eu.nurkert.neverUp2Late.update.UpdateSourceRegistry updateSourceRegistry;
+    private final UpdateSourceRegistry updateSourceRegistry;
     private final PluginLifecycleManager pluginLifecycleManager;
     private final PluginUpdateSettingsRepository pluginUpdateSettingsRepository;
     private final SetupStateRepository setupStateRepository;
@@ -35,7 +49,7 @@ public class PluginContext {
                          PersistentPluginHandler persistentPluginHandler,
                          UpdateHandler updateHandler,
                          InstallationHandler installationHandler,
-                         eu.nurkert.neverUp2Late.update.UpdateSourceRegistry updateSourceRegistry,
+                         UpdateSourceRegistry updateSourceRegistry,
                          PluginLifecycleManager pluginLifecycleManager,
                          PluginUpdateSettingsRepository pluginUpdateSettingsRepository,
                          SetupStateRepository setupStateRepository,
@@ -77,7 +91,7 @@ public class PluginContext {
         return installationHandler;
     }
 
-    public eu.nurkert.neverUp2Late.update.UpdateSourceRegistry getUpdateSourceRegistry() {
+    public UpdateSourceRegistry getUpdateSourceRegistry() {
         return updateSourceRegistry;
     }
 
@@ -95,5 +109,134 @@ public class PluginContext {
 
     public ArtifactDownloader getArtifactDownloader() {
         return artifactDownloader;
+    }
+
+    public List<UpdateSourceStatus> getUpdateSourceStatuses() {
+        if (updateSourceRegistry == null) {
+            return Collections.emptyList();
+        }
+
+        List<UpdateSource> sources = updateSourceRegistry.getSources();
+        if (sources.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<String, PluginState> storedStates = Collections.emptyMap();
+        if (persistentPluginHandler != null) {
+            List<String> names = new ArrayList<>(sources.size());
+            for (UpdateSource source : sources) {
+                if (source == null) {
+                    continue;
+                }
+                String name = source.getName();
+                if (name != null && !name.isBlank()) {
+                    names.add(name);
+                }
+            }
+            storedStates = persistentPluginHandler.getPluginStates(names);
+        }
+
+        Map<String, PluginState> stateLookup = new HashMap<>(storedStates);
+        List<UpdateSourceStatus> result = new ArrayList<>(sources.size());
+
+        for (UpdateSource source : sources) {
+            if (source == null) {
+                continue;
+            }
+
+            String sourceName = source.getName();
+            Path targetPath = resolveTargetPath(source);
+            PluginState pluginState = sourceName != null ? stateLookup.get(sourceName) : null;
+            Integer build = pluginState != null && pluginState.build() >= 0 ? pluginState.build() : null;
+            String version = pluginState != null ? pluginState.version() : null;
+
+            String pluginName = resolvePluginName(source, targetPath);
+            boolean autoUpdate = true;
+            if (pluginUpdateSettingsRepository != null) {
+                PluginUpdateSettings settings = pluginUpdateSettingsRepository.getSettings(pluginName);
+                autoUpdate = settings.autoUpdateEnabled();
+            }
+
+            result.add(new UpdateSourceStatus(
+                    sourceName,
+                    pluginName,
+                    source.getTargetDirectory(),
+                    targetPath,
+                    build,
+                    version,
+                    autoUpdate
+            ));
+        }
+
+        return result;
+    }
+
+    private Path resolveTargetPath(UpdateSource source) {
+        if (source == null) {
+            return null;
+        }
+        File pluginsFolder = plugin.getDataFolder().getParentFile();
+        File serverFolder = plugin.getServer().getWorldContainer().getAbsoluteFile();
+        File base = source.getTargetDirectory() == TargetDirectory.SERVER ? serverFolder : pluginsFolder;
+        if (base == null) {
+            return null;
+        }
+        String filename = source.getFilename();
+        File destination = filename != null && !filename.isBlank()
+                ? new File(base, filename)
+                : base;
+        return destination.toPath().toAbsolutePath().normalize();
+    }
+
+    private String resolvePluginName(UpdateSource source, Path targetPath) {
+        if (source == null) {
+            return null;
+        }
+        String installedPlugin = source.getInstalledPluginName();
+        if (installedPlugin != null && !installedPlugin.isBlank()) {
+            return installedPlugin;
+        }
+        if (pluginLifecycleManager == null || targetPath == null) {
+            return null;
+        }
+        return pluginLifecycleManager.findByPath(targetPath)
+                .map(ManagedPlugin::getName)
+                .orElse(null);
+    }
+
+    public record UpdateSourceStatus(String sourceName,
+                                     String pluginName,
+                                     TargetDirectory targetDirectory,
+                                     Path targetPath,
+                                     Integer lastBuild,
+                                     String lastVersion,
+                                     boolean autoUpdateEnabled) {
+
+        public boolean hasBuildInformation() {
+            return lastBuild != null || (lastVersion != null && !lastVersion.isBlank());
+        }
+
+        public String displayName() {
+            return sourceName != null ? sourceName : "Unknown source";
+        }
+
+        public String pluginDisplayName() {
+            return pluginName != null && !pluginName.isBlank() ? pluginName : "unassigned";
+        }
+
+        public String versionLabel() {
+            boolean hasVersion = lastVersion != null && !lastVersion.isBlank();
+            boolean hasBuild = lastBuild != null;
+            if (hasVersion && hasBuild) {
+                return "Version " + lastVersion + " (Build " + lastBuild + ")";
+            }
+            if (hasVersion) {
+                return "Version " + lastVersion;
+            }
+            if (hasBuild) {
+                return "Build " + lastBuild;
+            }
+            return "No installation recorded";
+        }
     }
 }

--- a/src/main/java/eu/nurkert/neverUp2Late/handlers/PersistentPluginHandler.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/handlers/PersistentPluginHandler.java
@@ -4,6 +4,10 @@ import eu.nurkert.neverUp2Late.persistence.UpdateStateRepository;
 import eu.nurkert.neverUp2Late.persistence.UpdateStateRepository.PluginState;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public class PersistentPluginHandler {
@@ -32,6 +36,21 @@ public class PersistentPluginHandler {
 
     public Optional<PluginState> getPluginState(String pluginName) {
         return repository.find(pluginName);
+    }
+
+    public Map<String, PluginState> getPluginStates(Collection<String> pluginNames) {
+        if (pluginNames == null || pluginNames.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, PluginState> states = new HashMap<>();
+        for (String name : pluginNames) {
+            if (name == null || name.isBlank()) {
+                continue;
+            }
+            repository.find(name).ifPresent(state -> states.put(name, state));
+        }
+        return states;
     }
 
     public boolean hasPluginInfo(String pluginName) {


### PR DESCRIPTION
## Summary
- add a `/nu2l status` subcommand that surfaces update source information in chat and console
- expose aggregated update source state via `PluginContext` using `PersistentPluginHandler` and plugin update settings
- document the new command, permissions, and sample output in the README

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68dfd4a3e2a883228da2b602a63befd4