### PR TITLE
Prevent setup wizard continue button from toggling sources

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/setup/InitialSetupManager.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/setup/InitialSetupManager.java
@@ -296,6 +296,9 @@ public class InitialSetupManager implements Listener {
         session.slotMapping.clear();
         int slotIndex = 9;
         for (SourceConfiguration source : session.sources) {
+            while (slotIndex < INVENTORY_SIZE && slotIndex == CONTINUE_SLOT) {
+                slotIndex++;
+            }
             if (slotIndex >= INVENTORY_SIZE) {
                 break;
             }
@@ -303,6 +306,8 @@ public class InitialSetupManager implements Listener {
             session.slotMapping.put(slotIndex, source);
             slotIndex++;
         }
+
+        session.slotMapping.remove(CONTINUE_SLOT);
 
         ItemStack continueItem = new ItemStack(Material.LIME_CONCRETE);
         ItemMeta continueMeta = continueItem.getItemMeta();


### PR DESCRIPTION
## Summary
- skip the continue button slot when laying out setup wizard source entries
- clear slot mappings so clicking "Speichern" advances the setup flow instead of toggling a source

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dffa58c47883228c702db084a5692b