### PR TITLE
Add CurseForge quick install support

### DIFF
--- a/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
@@ -51,6 +51,49 @@ class QuickInstallCoordinatorTest {
     }
 
     @Test
+    void extractCurseforgeProjectReturnsSlugFromBasePath() {
+        Optional<QuickInstallCoordinator.CurseforgeProjectPath> project =
+                QuickInstallCoordinator.extractCurseforgeProject(List.of("minecraft", "bukkit-plugins", "treetimber"));
+
+        assertTrue(project.isPresent());
+        QuickInstallCoordinator.CurseforgeProjectPath path = project.orElseThrow();
+        assertEquals(2, path.slugIndex());
+        assertEquals("treetimber", path.slug());
+    }
+
+    @Test
+    void extractCurseforgeProjectSkipsDownloadSegments() {
+        Optional<QuickInstallCoordinator.CurseforgeProjectPath> project = QuickInstallCoordinator.extractCurseforgeProject(
+                List.of("minecraft", "bukkit-plugins", "treetimber", "download", "5102550")
+        );
+
+        assertTrue(project.isPresent());
+        QuickInstallCoordinator.CurseforgeProjectPath path = project.orElseThrow();
+        assertEquals(2, path.slugIndex());
+        assertEquals("treetimber", path.slug());
+    }
+
+    @Test
+    void extractCurseforgeProjectDecodesSlug() {
+        Optional<QuickInstallCoordinator.CurseforgeProjectPath> project = QuickInstallCoordinator.extractCurseforgeProject(
+                List.of("minecraft", "bukkit-plugins", "My%20Plugin", "files", "12345")
+        );
+
+        assertTrue(project.isPresent());
+        QuickInstallCoordinator.CurseforgeProjectPath path = project.orElseThrow();
+        assertEquals(2, path.slugIndex());
+        assertEquals("My Plugin", path.slug());
+    }
+
+    @Test
+    void extractCurseforgeProjectReturnsEmptyWhenMissingSlug() {
+        Optional<QuickInstallCoordinator.CurseforgeProjectPath> project =
+                QuickInstallCoordinator.extractCurseforgeProject(List.of("minecraft", "bukkit-plugins"));
+
+        assertFalse(project.isPresent());
+    }
+
+    @Test
     void extractOwnerAndSlugSkipsPrefixesForHangar() {
         Optional<QuickInstallCoordinator.OwnerSlug> result = QuickInstallCoordinator.extractOwnerAndSlug(
                 List.of("project", "PaperMC", "Paper", "versions"),


### PR DESCRIPTION
## Summary
- add CurseForge quick install detection that fetches the project id from the project page and configures the curseforge fetcher
- add heuristics and unit tests for parsing CurseForge project slugs and ignoring trailing/category segments

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e042505c848322bf5ab627b47f702b