### PR TITLE
Increase default update check interval to 3 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ filenames:
   geyser: "Geyser-Spigot.jar"
   paper: "paper.jar"
 
-updateInterval: 30
+updateInterval: 180
 pluginLifecycle:
   autoManage: true
 quickInstall:
@@ -163,7 +163,7 @@ updates:
 Key options:
 
 - `setup.skipWizard` – When `true`, NeverUp2Late skips the interactive wizard and applies default sources on startup.
-- `updateInterval` – Minutes between scheduled update checks.
+- `updateInterval` – Minutes between scheduled update checks (default: 180 minutes / 3 hours).
 - `pluginLifecycle.autoManage` – Enables automatic plugin reloads and lifecycle controls. Set to `false` to keep manual restarts.
 - `quickInstall.ignoreCompatibilityWarnings` – When `true`, the quick install workflow skips Minecraft-version compatibility
   checks reported by providers like Modrinth and installs the latest build regardless.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,7 +11,7 @@ filenames:
   paper: "paper.jar"
 
 # Check interval in minutes
-updateInterval: 30
+updateInterval: 180
 
 # Controls automatic plugin lifecycle operations (reload/unload).
 pluginLifecycle:


### PR DESCRIPTION
## Summary
- change the default `updateInterval` in the bundled configuration to 180 minutes
- document the new 3-hour default interval in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e049fa58108322be8a51b2c1c811e0