### PR TITLE
Add Spigot quick install detection

### DIFF
--- a/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
@@ -1,9 +1,20 @@
 package eu.nurkert.neverUp2Late.command;
 
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import eu.nurkert.neverUp2Late.update.UpdateSourceRegistry.TargetDirectory;
+
+import sun.misc.Unsafe;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -127,5 +138,86 @@ class QuickInstallCoordinatorTest {
         );
 
         assertFalse(result.isPresent());
+    }
+
+    @Test
+    void extractSpigotResourceParsesSlugAndId() {
+        Optional<QuickInstallCoordinator.SpigotResource> result = QuickInstallCoordinator.extractSpigotResource(
+                List.of("resources", "chunky.81534", "download")
+        );
+
+        assertTrue(result.isPresent());
+        QuickInstallCoordinator.SpigotResource resource = result.orElseThrow();
+        assertEquals(81534L, resource.resourceId());
+        assertEquals("chunky", resource.slug());
+    }
+
+    @Test
+    void extractSpigotResourceFallsBackForNumericPaths() {
+        Optional<QuickInstallCoordinator.SpigotResource> result = QuickInstallCoordinator.extractSpigotResource(
+                List.of("resources", "81534", "download")
+        );
+
+        assertTrue(result.isPresent());
+        QuickInstallCoordinator.SpigotResource resource = result.orElseThrow();
+        assertEquals(81534L, resource.resourceId());
+        assertEquals("resource-81534", resource.slug());
+    }
+
+    @Test
+    void analyseCreatesSpigotPlanWithCompatibilityPreference() throws Exception {
+        QuickInstallCoordinator coordinator = newCoordinator(true);
+        Method analyse = QuickInstallCoordinator.class.getDeclaredMethod("analyse", URI.class, String.class);
+        analyse.setAccessible(true);
+
+        String url = "https://www.spigotmc.org/resources/chunky.81534/download?version=123456";
+        Object plan = analyse.invoke(coordinator, URI.create(url), url);
+
+        Method getFetcherType = plan.getClass().getDeclaredMethod("getFetcherType");
+        getFetcherType.setAccessible(true);
+        assertEquals("spigot", getFetcherType.invoke(plan));
+
+        Method getTargetDirectory = plan.getClass().getDeclaredMethod("getTargetDirectory");
+        getTargetDirectory.setAccessible(true);
+        assertEquals(TargetDirectory.PLUGINS, getTargetDirectory.invoke(plan));
+
+        Method getOptions = plan.getClass().getDeclaredMethod("getOptions");
+        getOptions.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> options = (Map<String, Object>) getOptions.invoke(plan);
+        assertEquals(81534L, options.get("resourceId"));
+        assertEquals(Boolean.TRUE, options.get("ignoreCompatibilityWarnings"));
+
+        Method getDefaultFilename = plan.getClass().getDeclaredMethod("getDefaultFilename");
+        getDefaultFilename.setAccessible(true);
+        assertEquals("chunky.jar", getDefaultFilename.invoke(plan));
+
+        Method getPluginNameCandidates = plan.getClass().getDeclaredMethod("getPluginNameCandidates");
+        getPluginNameCandidates.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Set<String> candidates = (Set<String>) getPluginNameCandidates.invoke(plan);
+        assertTrue(candidates.contains("chunky"));
+        assertTrue(candidates.contains("Chunky"));
+    }
+
+    private QuickInstallCoordinator newCoordinator(boolean ignoreCompatibilityWarnings) throws Exception {
+        Unsafe unsafe = getUnsafe();
+        QuickInstallCoordinator coordinator = (QuickInstallCoordinator) unsafe.allocateInstance(QuickInstallCoordinator.class);
+        setField(coordinator, "configuration", new YamlConfiguration());
+        setField(coordinator, "ignoreCompatibilityWarnings", ignoreCompatibilityWarnings);
+        setField(coordinator, "logger", Logger.getLogger("QuickInstallCoordinatorTest"));
+        return coordinator;
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = QuickInstallCoordinator.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private Unsafe getUnsafe() throws Exception {
+        Field field = Unsafe.class.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        return (Unsafe) field.get(null);
     }
 }


### PR DESCRIPTION
## Summary
- add quick install analysis for SpigotMC and Spiget URLs with parsed resource metadata
- honour compatibility preference when building the new installation plan and expose plugin name candidates
- cover the new Spigot parsing and installation plan logic with unit tests

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e049985e448322b1615473c86ae073