### PR TITLE
Bump plugin version to 2.1.0

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: NeverUp2Late
-version: '1.1.1'
+version: '2.1.0'
 main: eu.nurkert.neverUp2Late.NeverUp2Late
 author: nurkert
 api-version: '1.21'


### PR DESCRIPTION
## Summary
- update the declared plugin version to 2.1.0 in plugin.yml

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e04c3ad7a08322a4c00c886ee9098a