### PR TITLE
Fix CurseForge 403 errors and bump version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.nurkert</groupId>
     <artifactId>never-up-2-late</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -149,7 +149,11 @@ public class QuickInstallCoordinator {
         this.pluginUpdateSettingsRepository = context.getPluginUpdateSettingsRepository();
         this.pluginLifecycleManager = context.getPluginLifecycleManager();
         this.artifactDownloader = Objects.requireNonNullElseGet(context.getArtifactDownloader(), ArtifactDownloader::new);
-        this.httpClient = HttpClient.builder().accept("text/html,application/xhtml+xml").build();
+        this.httpClient = HttpClient.builder()
+                .accept("text/html,application/xhtml+xml")
+                .header("User-Agent", HttpClient.DEFAULT_USER_AGENT)
+                .header("Accept-Language", "en-US,en;q=0.9")
+                .build();
         this.logger = plugin.getLogger();
         this.messagePrefix = ChatColor.GRAY + "[" + ChatColor.AQUA + "nu2l" + ChatColor.GRAY + "] " + ChatColor.RESET;
         this.ignoreCompatibilityWarnings = configuration.getBoolean("quickInstall.ignoreCompatibilityWarnings", false);

--- a/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/net/HttpClient.java
@@ -16,10 +16,13 @@ import java.util.Objects;
  */
 public class HttpClient {
 
+    public static final String DEFAULT_USER_AGENT =
+            "Mozilla/5.0 (compatible; NeverUp2Late/1.0; +https://github.com/nurkert/never-up-2-late)";
+
     private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(10);
     private static final Map<String, String> DEFAULT_HEADERS = Map.of(
-            "User-Agent", "never-up-2-late/1.0",
+            "User-Agent", DEFAULT_USER_AGENT,
             "Accept", "application/json"
     );
 


### PR DESCRIPTION
## Summary
- update the default HTTP headers to use a browser-like user agent
- ensure quick install requests include language hints to avoid CurseForge 403s
- send CurseForge-friendly headers during downloads and bump the patch version

## Testing
- mvn -q -DskipTests=false test

------
https://chatgpt.com/codex/tasks/task_e_68e057b712388322b96dc17581508bb5