### PR TITLE
Bump plugin version to 2.1.1

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: NeverUp2Late
-version: '2.1.0'
+version: '2.1.1'
 main: eu.nurkert.neverUp2Late.NeverUp2Late
 author: nurkert
 api-version: '1.21'


### PR DESCRIPTION
## Summary
- update the plugin metadata to reflect version 2.1.1

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e05a40401083228c8ba69e94df377c