### PR TITLE
Fix CurseForge quick install lookups against website 403

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -151,7 +151,8 @@ public class QuickInstallCoordinator {
         this.artifactDownloader = Objects.requireNonNullElseGet(context.getArtifactDownloader(), ArtifactDownloader::new);
         this.httpClient = HttpClient.builder()
                 .accept("text/html,application/xhtml+xml")
-                .header("User-Agent", HttpClient.DEFAULT_USER_AGENT)
+                .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
                 .header("Accept-Language", "en-US,en;q=0.9")
                 .build();
         this.logger = plugin.getLogger();


### PR DESCRIPTION
## Summary
- change the QuickInstall HTTP client to send a browser-like User-Agent string when contacting CurseForge
- ensure quick install requests continue to include HTML-friendly accept headers so project IDs can be parsed

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e05e5752188322ad581bf9dcc0f2fa