### PR TITLE
Prompt quick install users to override compatibility warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,12 @@ The command prints colour-coded lines in-game and plain text in the console, so 
    for smarter update checks.
 3. **Fetch latest build info** – Version metadata and download URLs are loaded asynchronously; the chat shows progress and detected
    version numbers.
-4. **Handle archives or multiple assets** – If the release exposes several files or zipped distributions, the player is prompted to
+4. **Resolve compatibility warnings** – If the provider does not advertise support for your Minecraft version, the workflow pauses
+   and asks whether to ignore the warning. Use `/nu2l ignore` to proceed with the newest build or `/nu2l cancel` to abort the
+   installation.
+5. **Handle archives or multiple assets** – If the release exposes several files or zipped distributions, the player is prompted to
    pick the desired asset or JAR inside the archive; regex patterns are stored automatically for future updates.
-5. **Schedule installation** – Once information is complete, the update handler copies the build into the configured directory and
+6. **Schedule installation** – Once information is complete, the update handler copies the build into the configured directory and
    applies lifecycle rules (reload or restart).
 
 ![Quick install linking an update source from a URL](images/update-source-configured-by-link.png)

--- a/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/NeverUp2LateCommand.java
@@ -73,6 +73,24 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
+        if (args.length > 0 && "ignore".equalsIgnoreCase(args[0])) {
+            if (!sender.hasPermission(Permissions.INSTALL)) {
+                sender.sendMessage(ChatColor.RED + "You do not have permission to manage installations.");
+                return true;
+            }
+            coordinator.confirmCompatibilityOverride(sender);
+            return true;
+        }
+
+        if (args.length > 0 && "cancel".equalsIgnoreCase(args[0])) {
+            if (!sender.hasPermission(Permissions.INSTALL)) {
+                sender.sendMessage(ChatColor.RED + "You do not have permission to manage installations.");
+                return true;
+            }
+            coordinator.cancelCompatibilityOverride(sender);
+            return true;
+        }
+
         if (args.length > 0 && "setup".equalsIgnoreCase(args[0])) {
             if (setupManager == null) {
                 sender.sendMessage(ChatColor.RED + "The setup utilities are not available.");
@@ -188,7 +206,7 @@ public class NeverUp2LateCommand implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            return List.of("gui", "status", "select", "remove", "setup", "rollback");
+            return List.of("gui", "status", "select", "ignore", "cancel", "remove", "setup", "rollback");
         }
         if (args.length == 2 && "select".equalsIgnoreCase(args[0])) {
             return Collections.singletonList("<number>");

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/ModrinthFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/ModrinthFetcher.java
@@ -2,6 +2,7 @@ package eu.nurkert.neverUp2Late.fetcher;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
+import eu.nurkert.neverUp2Late.fetcher.exception.CompatibilityMismatchException;
 import eu.nurkert.neverUp2Late.net.HttpClient;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -142,7 +143,13 @@ public class ModrinthFetcher extends JsonUpdateFetcher {
                 .collect(Collectors.toSet());
 
         if (matching.isEmpty()) {
-            throw new IOException("No game versions available matching preferences " + preferredGameVersions);
+            throw new CompatibilityMismatchException(
+                    "No game versions available matching preferences " + preferredGameVersions,
+                    null,
+                    versions.stream()
+                            .flatMap(version -> version.gameVersions().stream())
+                            .collect(Collectors.toCollection(java.util.LinkedHashSet::new))
+            );
         }
 
         Set<String> compatible = filterByMaximumVersion(matching, maximumGameVersion, comparator);

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/SpigotFetcher.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/SpigotFetcher.java
@@ -1,6 +1,7 @@
 package eu.nurkert.neverUp2Late.fetcher;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import eu.nurkert.neverUp2Late.fetcher.exception.CompatibilityMismatchException;
 import eu.nurkert.neverUp2Late.net.HttpClient;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -180,8 +181,10 @@ public class SpigotFetcher extends JsonUpdateFetcher {
                 || matchesAny(preferredGameVersions, availableVersions);
         if (!matchesPreferred) {
             if (!ignoreCompatibilityWarnings) {
-                throw new IOException("Spigot resource " + resourceId
-                        + " does not target preferred game versions " + preferredGameVersions);
+                throw new CompatibilityMismatchException("Spigot resource " + resourceId
+                        + " does not target preferred game versions " + preferredGameVersions,
+                        null,
+                        availableVersions);
             }
             return;
         }
@@ -197,8 +200,10 @@ public class SpigotFetcher extends JsonUpdateFetcher {
 
         Set<String> candidates = expandVersionCandidates(serverVersion);
         if (!matchesAny(candidates, availableVersions)) {
-            throw new IOException("Spigot resource " + resourceId + " was not tested with server version "
-                    + serverVersion);
+            throw new CompatibilityMismatchException("Spigot resource " + resourceId
+                    + " was not tested with server version " + serverVersion,
+                    serverVersion,
+                    availableVersions);
         }
     }
 

--- a/src/main/java/eu/nurkert/neverUp2Late/fetcher/exception/CompatibilityMismatchException.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/fetcher/exception/CompatibilityMismatchException.java
@@ -1,0 +1,41 @@
+package eu.nurkert.neverUp2Late.fetcher.exception;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Signals that no release matching the currently configured or running Minecraft version
+ * could be found. Callers may choose to ignore this warning and retry the fetch with
+ * compatibility checks disabled.
+ */
+public class CompatibilityMismatchException extends IOException {
+
+    private final String serverVersion;
+    private final List<String> availableVersions;
+
+    public CompatibilityMismatchException(String message,
+                                          String serverVersion,
+                                          Collection<String> availableVersions) {
+        super(message);
+        this.serverVersion = serverVersion;
+        if (availableVersions == null || availableVersions.isEmpty()) {
+            this.availableVersions = List.of();
+        } else {
+            this.availableVersions = List.copyOf(availableVersions);
+        }
+    }
+
+    public String getServerVersion() {
+        return serverVersion;
+    }
+
+    public List<String> getAvailableVersions() {
+        return availableVersions;
+    }
+
+    @Override
+    public String toString() {
+        return getMessage();
+    }
+}


### PR DESCRIPTION
## Summary
- add a CompatibilityMismatchException and use it when Spigot or Modrinth fetchers cannot match the server version
- prompt the quick-install workflow to confirm ignoring compatibility warnings and provide /nu2l ignore and /nu2l cancel commands
- document the new compatibility override step in the quick-install workflow documentation

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e2fc2a37208322ad5e075fc0a37836