### PR TITLE
Fix quick install filename for Spiget downloads

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -1351,15 +1351,18 @@ public class QuickInstallCoordinator {
     }
 
     private String determineFilename(String downloadUrl, String fallback) {
+        String sanitizedFallback = fallback != null && !fallback.isBlank() ? fallback : null;
         try {
             URI uri = new URI(downloadUrl);
             String path = Optional.ofNullable(uri.getPath()).orElse("");
             int lastSlash = path.lastIndexOf('/');
             String candidate = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
-            candidate = candidate.isBlank() ? fallback : candidate;
             candidate = candidate.split("\\?")[0];
-            if (candidate.isBlank()) {
-                candidate = fallback;
+            if (candidate.isBlank() || !candidate.contains(".")) {
+                candidate = sanitizedFallback != null ? sanitizedFallback : candidate;
+            }
+            if (candidate == null || candidate.isBlank()) {
+                candidate = "download.jar";
             }
             if (!candidate.contains(".")) {
                 candidate = candidate + ".jar";
@@ -1367,7 +1370,7 @@ public class QuickInstallCoordinator {
             return candidate;
         } catch (Exception e) {
             logger.log(Level.FINE, "Failed to parse filename from " + downloadUrl, e);
-            return fallback;
+            return sanitizedFallback != null ? sanitizedFallback : fallback;
         }
     }
 

--- a/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
@@ -200,6 +200,24 @@ class QuickInstallCoordinatorTest {
         assertTrue(candidates.contains("Chunky"));
     }
 
+    @Test
+    void determineFilenameFallsBackWhenDownloadNameGeneric() throws Exception {
+        QuickInstallCoordinator coordinator = newCoordinator(false);
+        Method method = QuickInstallCoordinator.class.getDeclaredMethod(
+                "determineFilename",
+                String.class,
+                String.class
+        );
+        method.setAccessible(true);
+
+        String fallback = "chunky.jar";
+        String result = (String) method.invoke(coordinator,
+                "https://api.spiget.org/v2/resources/chunky.81534/download",
+                fallback);
+
+        assertEquals(fallback, result);
+    }
+
     private QuickInstallCoordinator newCoordinator(boolean ignoreCompatibilityWarnings) throws Exception {
         Unsafe unsafe = getUnsafe();
         QuickInstallCoordinator coordinator = (QuickInstallCoordinator) unsafe.allocateInstance(QuickInstallCoordinator.class);


### PR DESCRIPTION
## Summary
- ensure quick install falls back to the default filename when Spiget download URLs end in a generic `download` segment
- add regression test covering the filename fallback logic for Spiget resources

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68e31590211c8322934c3e2ff350d723