### PR TITLE
Add self-update option and GUI handling for NeverUp2Late

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/NeverUp2Late.java
@@ -54,6 +54,7 @@ public final class NeverUp2Late extends JavaPlugin {
                     getLogger()
             );
             pluginLifecycleManager.registerLoadedPlugins(this);
+            pluginLifecycleManager.registerPlugin(this);
         } else {
             getLogger().fine("Plugin lifecycle management is disabled (pluginLifecycle.autoManage=false).");
         }


### PR DESCRIPTION
## Summary
- add an automatic NeverUp2Late update source to the setup wizard and persist the chosen auto-update preference
- register the plugin with the lifecycle manager so it appears in the GUI and show contextual messaging when it is selected
- safeguard GUI and coordinator actions so NeverUp2Late cannot unload, rename, or remove itself while still allowing preference changes

## Testing
- `mvn -q -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68e3e887e3648322a68d78f0d23466ad