### PR TITLE
Fix quick install source naming after removing conflicts

### DIFF
--- a/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
+++ b/src/main/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinator.java
@@ -912,6 +912,8 @@ public class QuickInstallCoordinator {
             removeConflictingSources(sender, conflicts);
         }
 
+        ensurePreferredSourceName(plan);
+
         if (updateSourceRegistry.hasSource(plan.getSourceName())) {
             send(sender, ChatColor.YELLOW + "Source already exists, starting update…");
             UpdateSource existing = updateSourceRegistry.findSource(plan.getSourceName()).orElse(null);
@@ -1673,6 +1675,27 @@ public class QuickInstallCoordinator {
             candidate = base + "-" + counter++;
         }
         return candidate;
+    }
+
+    private void ensurePreferredSourceName(InstallationPlan plan) {
+        if (plan == null || updateSourceRegistry == null) {
+            return;
+        }
+
+        String suggested = plan.getSuggestedName();
+        if (suggested == null || suggested.isBlank()) {
+            return;
+        }
+
+        String current = plan.getSourceName();
+        if (current == null || current.isBlank()
+                || current.equals(suggested)
+                || current.startsWith(suggested + "-")) {
+            String preferred = ensureUniqueName(suggested);
+            if (!preferred.equals(current)) {
+                plan.setSourceName(preferred);
+            }
+        }
     }
 
     private void send(CommandSender sender, String message) {

--- a/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
+++ b/src/test/java/eu/nurkert/neverUp2Late/command/QuickInstallCoordinatorTest.java
@@ -259,6 +259,28 @@ class QuickInstallCoordinatorTest {
     }
 
     @Test
+    void ensurePreferredSourceNameRestoresSuggestedNameWhenAvailable() throws Exception {
+        QuickInstallCoordinator coordinator = newCoordinator(false);
+        UpdateSourceRegistry registry = new UpdateSourceRegistry(Logger.getLogger("test"), new YamlConfiguration());
+        setField(coordinator, "updateSourceRegistry", registry);
+
+        Object plan = newInstallationPlan(coordinator, "spigot", "coreprotect", "CoreProtect");
+        Class<?> planClass = plan.getClass();
+
+        Method setSourceName = planClass.getDeclaredMethod("setSourceName", String.class);
+        setSourceName.setAccessible(true);
+        setSourceName.invoke(plan, "coreprotect-1");
+
+        Method ensurePreferred = QuickInstallCoordinator.class.getDeclaredMethod("ensurePreferredSourceName", planClass);
+        ensurePreferred.setAccessible(true);
+        ensurePreferred.invoke(coordinator, plan);
+
+        Method getSourceName = planClass.getDeclaredMethod("getSourceName");
+        getSourceName.setAccessible(true);
+        assertEquals("coreprotect", getSourceName.invoke(plan));
+    }
+
+    @Test
     void findConflictingSourcesDetectsExistingByInstalledPlugin() throws Exception {
         QuickInstallCoordinator coordinator = newCoordinator(false);
         UpdateSourceRegistry registry = new UpdateSourceRegistry(Logger.getLogger("test"), new YamlConfiguration());


### PR DESCRIPTION
## Summary
- make quick install re-evaluate the preferred source name after duplicate sources are removed
- add coverage to ensure the preferred name is restored when available

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68e5251807fc83229f87342894c459f8